### PR TITLE
bos rework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 		"**/.pnp.*": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -20448,6 +20448,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"csB" = (
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "csG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -23132,6 +23136,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/f13/seniorscribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -55320,6 +55325,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/f13/paladincommander,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "spe" = (
@@ -100555,7 +100561,7 @@ nrV
 nrV
 qKq
 ecz
-oYF
+csB
 oYF
 mcP
 oxZ

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -118,10 +118,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aaC" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "aaD" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
@@ -148,12 +149,15 @@
 	},
 /area/f13/building)
 "aaK" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/seeds/cannabis,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/turf_decal/stripes/box,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "aaL" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -272,10 +276,13 @@
 	},
 /area/f13/building)
 "abg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/overlay/rockfloor_side,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "abh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/bundle/f13/armor/combat,
@@ -287,7 +294,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "abk" = (
 /obj/machinery/smartfridge/bottlerack/gardentool,
 /turf/open/floor/plasteel/f13/vault_floor/misc,
@@ -321,10 +328,13 @@
 	network = list("BoS")
 	},
 /obj/structure/tires/five,
+/obj/structure/fence{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "abt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirelurkegg,
@@ -383,9 +393,9 @@
 	},
 /area/f13/building/massfusion)
 "abI" = (
-/obj/effect/overlay/rockfloor_side,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "abL" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/road,
@@ -461,13 +471,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "acc" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
-/area/f13/building)
+/area/f13/brotherhood)
 "acd" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -503,12 +511,11 @@
 	},
 /area/f13/village)
 "ack" = (
-/obj/item/soap/homemade,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "acl" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -561,11 +568,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "acE" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/building)
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "acF" = (
 /obj/structure/closet/crate/large,
 /obj/machinery/light{
@@ -576,6 +592,11 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
+"acG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "acI" = (
 /obj/structure/fluff/rails{
 	dir = 4
@@ -672,13 +693,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "adb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bedsheetbin,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/building)
+/area/f13/brotherhood)
 "add" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -1585,10 +1604,9 @@
 	},
 /area/f13/wasteland)
 "ahC" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/fence/door,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "ahD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -2595,10 +2613,12 @@
 	},
 /area/f13/wasteland)
 "all" = (
-/obj/item/clothing/head/helmet/f13/brahmincowboyhat,
-/obj/item/clothing/suit/armor/light/duster/brahmin,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/stairs{
+	barefootstep = "woodbarefoot";
+	color = "#A47449";
+	footstep = "wood"
+	},
+/area/f13/brotherhood)
 "alo" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbrokenvertical"
@@ -2672,7 +2692,7 @@
 "alE" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "alF" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -13112,6 +13132,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"aXS" = (
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "aXT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -16035,12 +16062,22 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "blR" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "blU" = (
 /mob/living/simple_animal/pet/dog/eyebot{
 	desc = "This eyebot's weapons module has been removed and replaced with a loudspeaker. It appears to be shouting about Bighorn.";
@@ -16404,8 +16441,9 @@
 /area/f13/wasteland)
 "boC" = (
 /obj/structure/flora/grass/jungle/b,
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "boE" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -17658,6 +17696,18 @@
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"bCg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "bCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -17698,6 +17748,10 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bDn" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "bDx" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -17750,6 +17804,26 @@
 /obj/structure/punching_bag,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khans)
+"bEy" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
+	},
+/obj/structure/wreck/trash/machinepiletwo{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "bEK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -18255,7 +18329,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "bOd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -18311,6 +18385,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"bOK" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "bPg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18682,6 +18763,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
 /area/f13/village)
+"bYi" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "bYo" = (
 /obj/structure/timeddoor,
 /turf/closed/indestructible/f13/matrix,
@@ -18951,6 +19038,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"ceg" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "cej" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/machinery/autolathe,
@@ -20049,6 +20143,16 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"cqf" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/energy/laser/pistol{
+	step_y = 10
+	},
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "cqg" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/rollingpin,
@@ -20522,6 +20626,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cup" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
+/area/f13/brotherhood)
 "cuu" = (
 /mob/living/simple_animal/hostile/cazador,
 /obj/effect/decal/cleanable/dirt,
@@ -20821,11 +20930,14 @@
 	},
 /area/f13/building)
 "cAi" = (
-/obj/structure/statue/bos/ladyright{
-	pixel_y = -16
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
+"cAk" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "cAn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -21157,6 +21269,11 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
+"cLb" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "cLm" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
@@ -21340,9 +21457,14 @@
 /turf/open/floor/carpet/red,
 /area/f13/city)
 "cPG" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "cPO" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -21827,6 +21949,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ddA" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/structure/table/glass,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000"
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/medsprays,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/bag/chemistry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "ddC" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/structure/table/reinforced,
@@ -21957,6 +22096,10 @@
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dgg" = (
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dgi" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/effect/decal/cleanable/dirt,
@@ -22047,7 +22190,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "din" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/wastelander,
@@ -22453,6 +22596,11 @@
 	name = "rocky dirt"
 	},
 /area/f13/wasteland)
+"drq" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "drx" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -22663,6 +22811,13 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"dwu" = (
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dwF" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/ruins{
@@ -22716,6 +22871,15 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
+"dxu" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/charcoal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dxy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22815,6 +22979,10 @@
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dze" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dzg" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22925,6 +23093,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"dBo" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "dBr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -22937,20 +23112,30 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dBH" = (
-/obj/structure/filingcabinet{
-	pixel_x = 12;
-	pixel_y = 9
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/fluff/railing{
+	dir = 8
 	},
-/obj/structure/filingcabinet{
-	pixel_y = 9
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"dBK" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "dBY" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"dCm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "dCA" = (
 /obj/structure/flora/rock/pile/largejungle{
 	icon_state = "bush3"
@@ -23112,6 +23297,10 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"dGR" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood)
 "dHj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -23150,6 +23339,10 @@
 	color = "#e4e4e4"
 	},
 /area/f13/legion)
+"dHx" = (
+/obj/machinery/power/floodlight,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "dHD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirthole,
@@ -23431,6 +23624,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"dPv" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "dPz" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -23511,6 +23709,10 @@
 /obj/structure/sign/poster/prewar/poster74,
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
+"dRl" = (
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dRF" = (
 /obj/structure/rack,
 /obj/item/gun_upgrade/underbarrel/bipod,
@@ -23871,6 +24073,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/firestation)
+"eaF" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Armory";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "eaJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -23947,6 +24160,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/building/mall)
+"ecz" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/f13/paladin,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ecV" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -24089,6 +24310,37 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"efh" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/wrench/medical,
+/obj/item/toy/figure/cmo{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	layer = 2;
+	name = "Head Scribe Action Figure";
+	toysay = "Ad astra per aspera."
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "eft" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24198,7 +24450,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "ejn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24259,6 +24511,12 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"elE" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "elO" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/grass/wasteland{
@@ -24701,15 +24959,14 @@
 	},
 /area/f13/wasteland)
 "evU" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "ewh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24917,6 +25174,60 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/trainstation)
+"eAo" = (
+/obj/structure/rack,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "eAr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small/broken{
@@ -25031,7 +25342,7 @@
 "eDQ" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "eEg" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -25073,12 +25384,9 @@
 	},
 /area/f13/legion)
 "eEQ" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/concrete,
+/area/f13/brotherhood)
 "eES" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -25184,6 +25492,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"eHm" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "eHo" = (
 /obj/structure/railing/wood{
 	dir = 5;
@@ -25517,6 +25834,12 @@
 /obj/structure/flora/grass/coyote/one,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"eOO" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "eOS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/coyote/one,
@@ -25696,6 +26019,16 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
+"eSe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/Knight,
+/obj/effect/landmark/start/f13/seniorknight,
+/obj/effect/landmark/start/f13/seniorpaladin,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "eSg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25795,6 +26128,10 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
+"eUt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "eUA" = (
 /obj/structure/sink/greyscale{
 	dir = 8;
@@ -26218,7 +26555,7 @@
 /obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "fcs" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/water,
@@ -26342,10 +26679,9 @@
 	},
 /area/f13/wasteland)
 "ffb" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ffF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -26373,13 +26709,13 @@
 	},
 /area/f13/building)
 "fhn" = (
-/obj/structure/closet/cabinet{
-	pixel_x = -5;
-	pixel_y = 13
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/item/gun_upgrade/scope/watchman,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fhp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -27180,6 +27516,16 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fzB" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
+"fzD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "fzM" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland/khans)
@@ -27255,11 +27601,9 @@
 	},
 /area/f13/building)
 "fAT" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
-	},
+/obj/machinery/autolathe,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "fAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27549,7 +27893,12 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
+"fId" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "fIh" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27562,6 +27911,31 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"fIQ" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"fIY" = (
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_y = -6;
+	termtag = "Secret"
+	},
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "fJn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -27603,15 +27977,13 @@
 	},
 /area/f13/wasteland)
 "fJT" = (
-/obj/structure/bed{
-	pixel_y = 8
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/item/bedsheet{
-	icon_state = "sheethos";
-	pixel_y = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "fJU" = (
 /obj/structure/wreck/trash/one_tire,
 /turf/open/indestructible/ground/outside/road{
@@ -28145,14 +28517,41 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building/mall)
-"fYH" = (
-/obj/structure/reagent_dispensers/barrel/old{
-	pixel_x = -13;
-	pixel_y = 12
+"fYu" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"fYH" = (
+/obj/machinery/light,
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "fYQ" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/low_chance,
@@ -28457,6 +28856,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/village)
+"ghW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "gjj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28582,6 +28991,10 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/f13/store,
 /area/f13/building/hospital)
+"gmV" = (
+/obj/structure/closet/crate/miningcar,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "gnd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -28994,10 +29407,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/fence{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "gvO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -29088,6 +29504,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/khans)
+"gyt" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "gyw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29134,7 +29554,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "gyP" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/indestructible/rock{
@@ -29674,6 +30094,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
+"gJm" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/fluff/railing,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gKl" = (
 /obj/structure/flora/grass/coyote/two,
 /obj/structure/flora/brushwoodalt,
@@ -29942,6 +30375,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gOT" = (
+/obj/machinery/vending/clothing/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "gPj" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
@@ -30030,6 +30469,16 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
+"gSy" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "gSH" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -30084,6 +30533,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/village)
+"gTZ" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "gUg" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorygate";
@@ -30172,9 +30625,9 @@
 	},
 /area/f13/building)
 "gWQ" = (
-/obj/structure/simple_door/tent,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gWV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/glass,
@@ -30354,6 +30807,9 @@
 "gZM" = (
 /turf/open/transparent/openspace,
 /area/f13/building/museum)
+"gZN" = (
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "gZR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -30608,14 +31064,9 @@
 /turf/open/floor/carpet,
 /area/f13/city)
 "hgS" = (
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "hhk" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/weather/dirt{
@@ -30784,6 +31235,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"hmK" = (
+/obj/machinery/radioterminal/bos,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "hmM" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt{
@@ -31283,12 +31740,18 @@
 "hAE" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "hAT" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hBj" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "hBl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -31305,10 +31768,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "hBQ" = (
 /obj/structure/fence{
 	dir = 8
@@ -31323,6 +31785,15 @@
 	icon_state = "wide-broken1"
 	},
 /area/f13/wasteland)
+"hCt" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "hCJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -31364,6 +31835,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"hEc" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "hEh" = (
 /turf/open/indestructible/ground/outside/roaddirt{
 	dir = 4;
@@ -31450,6 +31936,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hGd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "hGv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -31953,8 +32452,9 @@
 /area/f13/wasteland)
 "hTq" = (
 /obj/structure/reagent_dispensers/barrel/old,
+/obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "hTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/coyote/one,
@@ -32016,6 +32516,10 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"hVd" = (
+/obj/structure/tires/two,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "hVk" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -32195,11 +32699,16 @@
 	},
 /area/f13/wasteland)
 "hZy" = (
-/obj/structure/statue/bos/ladyleft{
-	pixel_y = -16
+/obj/structure/bonfire/prelit,
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "hZB" = (
 /obj/structure/flora/grass/coyote/fourteen,
 /turf/open/indestructible/ground/outside/gravel,
@@ -32548,6 +33057,15 @@
 "iht" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
+"ihK" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ihN" = (
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32689,6 +33207,12 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"iml" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "imm" = (
 /obj/machinery/computer/terminal{
 	pixel_y = 5
@@ -33058,6 +33582,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"itC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "itH" = (
 /obj/structure/window/fulltile/house/broken,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -33150,6 +33680,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ivn" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/machinery/light/small,
+/turf/open/water,
+/area/f13/brotherhood)
 "ivJ" = (
 /obj/structure/bed/wooden,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -33216,6 +33770,23 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building/khanfort)
+"iwX" = (
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/book/granter/trait/pa_wear,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "ixb" = (
 /obj/structure/barricade/tentleatheredge,
 /turf/open/indestructible/ground/outside/desert,
@@ -33665,6 +34236,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"iFl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "iFm" = (
 /obj/item/reagent_containers/food/drinks/bottle/brown/greenwine,
 /obj/effect/decal/cleanable/dirt,
@@ -33819,7 +34398,7 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "iIm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -34056,10 +34635,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/khans)
+"iOf" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "iOh" = (
 /obj/structure/flora/tallgrass9,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iOo" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "iPb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -34228,6 +34820,18 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iSZ" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "iTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -34704,6 +35308,10 @@
 /obj/item/ammo_box/magazine/m556/rifle/small,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"jbk" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "jbl" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -34742,6 +35350,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jcI" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "jcW" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall/rust,
@@ -35308,6 +35925,10 @@
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/khans)
+"jra" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "jrj" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -36085,6 +36706,12 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/legion)
+"jMY" = (
+/obj/structure/chair/bench{
+	pixel_x = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "jNe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36138,6 +36765,10 @@
 /obj/item/melee/onehanded/knife/hunting,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jPz" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "jPC" = (
 /obj/structure/closet,
 /obj/item/storage/briefcase,
@@ -37066,6 +37697,12 @@
 /obj/item/pitchfork,
 /turf/open/floor/mineral/uranium,
 /area/f13/radiation)
+"kpw" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "kpC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -37777,6 +38414,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"kHE" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "kIc" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
@@ -38019,6 +38661,19 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/khans)
+"kMM" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/ballistic/automatic/pistol/beretta{
+	step_y = 5
+	},
+/obj/item/gun/ballistic/automatic/pistol/mk23,
+/obj/item/gun/ballistic/automatic/pistol/n99{
+	step_y = -5
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "kMY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
@@ -38112,11 +38767,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "kOC" = (
-/obj/structure/cargocrate{
-	pixel_x = 3
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood)
 "kOP" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -38153,6 +38810,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/building/khanfort)
+"kPp" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "kPz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
@@ -38373,6 +39036,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"kUZ" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "kVg" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -38436,6 +39111,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
+"kWx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "kWy" = (
 /obj/structure/fence{
 	dir = 4
@@ -38527,6 +39207,14 @@
 	name = "tile"
 	},
 /area/f13/building)
+"kYL" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "kYR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -38561,6 +39249,13 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
+"kZn" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "kZr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39103,6 +39798,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"llg" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "llo" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_fancy,
@@ -39240,6 +39941,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"lpN" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "lpY" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39545,13 +40252,11 @@
 	},
 /area/f13/building/massfusion)
 "lxR" = (
-/obj/structure/chair/wood{
-	dir = 1;
-	pixel_x = 7;
-	pixel_y = 5
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "lyo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -39735,6 +40440,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"lCq" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "lCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1,
@@ -39950,6 +40664,26 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"lGy" = (
+/obj/structure/bed{
+	pixel_y = 7
+	},
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	pixel_y = 7
+	},
+/obj/machinery/iv_drip{
+	pixel_x = 13;
+	pixel_y = 2
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "lGG" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/dirt,
@@ -40057,6 +40791,18 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"lIF" = (
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "lIH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/coyote/twelve,
@@ -40483,7 +41229,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "lRR" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -40845,6 +41591,12 @@
 /obj/effect/spawner/lootdrop/tool_box,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
+"lXK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "lYm" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -40970,9 +41722,16 @@
 	},
 /area/f13/ncr)
 "mbr" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "mbM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41049,6 +41808,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"mcP" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/structure/chair/f13foldupchair{
+	desc = "A folding chair, missing half the seat, probably for dropping something through it.";
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/paladin,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mdh" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -41107,6 +41878,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mes" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/caves)
 "mex" = (
 /obj/item/electropack/shockcollar/explosive,
 /obj/item/electropack/shockcollar/explosive,
@@ -41244,7 +42020,7 @@
 	pixel_x = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "mhm" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -41313,13 +42089,11 @@
 	},
 /area/f13/wasteland)
 "mjc" = (
-/obj/structure/simple_door/tent,
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/building)
+/area/f13/brotherhood)
 "mji" = (
 /obj/structure/fence/door{
 	max_integrity = 500;
@@ -41701,6 +42475,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"mqe" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "mqu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -42302,6 +43085,12 @@
 	color = "#e4e4e4"
 	},
 /area/f13/legion)
+"mFo" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "mFv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -42320,9 +43109,12 @@
 	},
 /area/f13/building/massfusion)
 "mFC" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/barricade/wooden,
+/obj/structure/obstacle/barbedwire{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "mFE" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt{
@@ -42449,6 +43241,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"mIe" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "mIh" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -42895,9 +43696,9 @@
 	},
 /area/f13/wasteland/khans)
 "mSr" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "mSu" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert/sonora/rough,
@@ -43218,10 +44019,14 @@
 	},
 /area/f13/building)
 "naO" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nbb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -43586,6 +44391,24 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel/southeast)
+"nja" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "njD" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -43688,6 +44511,32 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nmm" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "nmN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43952,6 +44801,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nrV" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"nse" = (
+/obj/structure/bonfire/prelit,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "nsn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44059,6 +44922,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/village)
+"nuO" = (
+/obj/machinery/microwave/stove,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "nvc" = (
 /obj/structure/fence/handrail{
 	pixel_y = -8
@@ -44228,6 +45095,14 @@
 /obj/machinery/smartfridge,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
+"nyr" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner/wasteland,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"nyE" = (
+/turf/open/indestructible/ground/outside/river,
+/area/f13/brotherhood)
 "nyK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -44254,10 +45129,8 @@
 	},
 /area/f13/wasteland)
 "nzb" = (
-/obj/structure/simple_door/tent,
-/obj/structure/decoration/rag,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/closed/wall/f13/tentwall,
+/area/f13/brotherhood)
 "nzi" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/effect/decal/cleanable/dirt,
@@ -44273,12 +45146,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
 "nzE" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "nzW" = (
 /obj/effect/decal/waste{
 	pixel_x = 20;
@@ -44363,13 +45237,23 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "nCn" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nCw" = (
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "nCG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -44380,6 +45264,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nCT" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/brotherhood)
 "nDc" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light/broken{
@@ -44416,6 +45308,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nDX" = (
+/obj/structure/bonfire/prelit,
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "nEg" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/vault,
@@ -44602,13 +45501,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nIo" = (
-/obj/structure/chair/wood{
-	dir = 1;
-	pixel_x = 8;
-	pixel_y = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "nIq" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -44672,6 +45569,21 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"nJS" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/robot_debris/old{
+	pixel_x = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "nJT" = (
 /obj/item/trash/f13/dandyapples,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44707,6 +45619,12 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"nLN" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "nLQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -44819,6 +45737,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
+"nPn" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "nPy" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorygate";
@@ -44853,7 +45780,7 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "nQt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44894,6 +45821,28 @@
 /obj/item/trash/candy,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nRn" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/under/rank/medical/green,
+/obj/item/clothing/under/rank/medical/purple,
+/obj/item/clothing/under/rank/medical/blue,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "nRt" = (
 /obj/structure/table,
 /obj/item/trash/f13/mre{
@@ -44979,7 +45928,7 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "nTE" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -45142,6 +46091,15 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"nYh" = (
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowbottom"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nYk" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt,
@@ -45309,6 +46267,10 @@
 	icon_state = "bar"
 	},
 /area/f13/caves)
+"oca" = (
+/obj/machinery/defibrillator_mount/loaded,
+/turf/closed/wall/mineral/concrete,
+/area/f13/brotherhood)
 "och" = (
 /obj/structure/wreck/car{
 	dir = 4;
@@ -45320,10 +46282,21 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"ocl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "ocu" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ocK" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/mineral/concrete,
+/area/f13/brotherhood)
 "ocZ" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/water,
@@ -45504,6 +46477,17 @@
 "ohr" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building/museum)
+"ohC" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
+/obj/item/key/vertibird,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ohD" = (
 /obj/machinery/mineral/wasteland_vendor/crafting,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45644,6 +46628,17 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
+"okx" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "okD" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -45727,6 +46722,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/f13/caves)
+"onr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "ons" = (
 /obj/structure/noticeboard{
 	layer = 3
@@ -45948,6 +46952,13 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland)
+"osD" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/flora/tree/oak_five,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "osE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/punching_bag,
@@ -46007,6 +47018,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"otY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "oue" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -46110,7 +47130,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "ovw" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/road{
@@ -46176,6 +47196,21 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"owY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "oxy" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -46187,6 +47222,13 @@
 /obj/structure/flora/grass/coyote/one,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"oxZ" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "oym" = (
 /obj/structure/rack,
 /obj/item/clothing/under/suit/charcoal,
@@ -46267,6 +47309,15 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"ozY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "oAa" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -46535,6 +47586,16 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"oHF" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "oHK" = (
 /obj/structure/flora/tree/tall,
 /obj/effect/decal/cleanable/dirt,
@@ -46572,6 +47633,11 @@
 	icon_state = "whiteyellowrustychess"
 	},
 /area/f13/city)
+"oIN" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "oIS" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -46828,6 +47894,10 @@
 /obj/structure/loom,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oNv" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "oNw" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt,
@@ -46985,6 +48055,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"oRb" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "oRs" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
@@ -47082,6 +48159,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"oUq" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "oUv" = (
 /obj/structure/displaycase,
 /obj/item/reagent_containers/food/drinks/bottle/nukashine,
@@ -47293,6 +48376,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
+"oYF" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "oYG" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/papersack,
@@ -47386,6 +48472,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"paC" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "paD" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/store,
@@ -47465,6 +48555,12 @@
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"pcP" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "pdm" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
@@ -47665,6 +48761,10 @@
 /obj/machinery/door/unpowered/secure_legion,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/caves)
+"php" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "phv" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/khans)
@@ -47871,6 +48971,13 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
+"pmI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/plantgenes/seedvault,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pmP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48260,7 +49367,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "ptN" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -48286,8 +49393,10 @@
 	pixel_y = 18
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "puK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -48416,6 +49525,9 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"pxe" = (
+/turf/closed/wall/mineral/concrete,
+/area/f13/brotherhood)
 "pxq" = (
 /obj/structure/rack,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -48583,9 +49695,9 @@
 	},
 /area/f13/building/trainstation)
 "pzs" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "pzB" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -48861,7 +49973,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "pFw" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -48947,7 +50059,7 @@
 	},
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "pHF" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -49009,6 +50121,18 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pJu" = (
+/obj/structure/bonfire/prelit,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "pJF" = (
 /obj/item/stack/sheet/bone,
 /turf/open/indestructible/ground/outside/dirt,
@@ -49032,10 +50156,16 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pKs" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "pKu" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "pKC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -49155,6 +50285,18 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"pNM" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/brotherhood)
+"pOm" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "pOR" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
@@ -49256,11 +50398,23 @@
 	},
 /area/f13/wasteland)
 "pRr" = (
-/obj/structure/closet/crate/miningcar,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/wasteland)
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "pRs" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /obj/structure/closet/secure_closet/goodies{
@@ -49403,6 +50557,14 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
+"pUx" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/flora/tree/oak_five,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "pUJ" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -49614,6 +50776,15 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/f13/building/museum)
+"qbF" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "qcb" = (
 /obj/structure/flora/rock/pile/largejungle{
 	icon_state = "bush3";
@@ -49650,7 +50821,7 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "qcY" = (
 /obj/machinery/microwave/stove,
 /obj/structure/decoration/clock{
@@ -49858,7 +51029,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "qhr" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -50244,6 +51415,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
+"qrD" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "qrV" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -50380,6 +51557,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"quz" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "quQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -50424,15 +51609,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qvQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood)
 "qvX" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -50447,6 +51625,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/ncr)
+"qwe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "qwF" = (
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
@@ -50789,7 +51976,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "qGB" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "housewindow"
@@ -50881,12 +52068,10 @@
 /area/f13/wasteland)
 "qIN" = (
 /obj/machinery/light/small,
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 5
-	},
+/obj/structure/table/wood,
+/obj/item/storage/box/mre,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "qIP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/bos{
@@ -50972,6 +52157,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"qKq" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "qKu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -50989,7 +52181,7 @@
 "qLb" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "qLd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -51098,6 +52290,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc,
 /area/f13/city)
+"qNs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "qNu" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -51213,7 +52410,7 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "qQl" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/khanfort)
@@ -51243,7 +52440,7 @@
 /obj/structure/simple_door/tent,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "qRg" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -51388,6 +52585,10 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/building/hospital)
+"qVg" = (
+/obj/structure/closet/fridge/meat,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "qVz" = (
 /obj/structure/chair/folding{
 	dir = 8
@@ -51632,6 +52833,13 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"qZU" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "qZV" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -51653,11 +52861,19 @@
 "ral" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "raI" = (
-/obj/structure/ore_box,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
@@ -51925,6 +53141,14 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"riV" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "riW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -52407,10 +53631,11 @@
 	},
 /area/f13/wasteland)
 "rxE" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "ryg" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/desert,
@@ -52588,6 +53813,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"rDz" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "rEa" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -53485,6 +54717,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rZY" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood)
 "saI" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/waste{
@@ -53690,6 +54930,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"sfd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sfo" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken5"
@@ -53793,6 +55039,12 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/f13/followers)
+"sio" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/sandbags,
+/obj/item/binoculars,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "siw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -54064,6 +55316,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"soF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "spe" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -54405,6 +55663,12 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"syf" = (
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "syF" = (
 /obj/structure/flora/branch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -54479,13 +55743,13 @@
 	},
 /area/f13/wasteland)
 "sAm" = (
-/obj/structure/chair/comfy{
-	color = "#ad0a0a";
-	pixel_x = -2;
-	pixel_y = 2
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "sAs" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
@@ -54845,10 +56109,9 @@
 	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "sKn" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -55173,6 +56436,13 @@
 	icon_state = "verticaloutermain2top"
 	},
 /area/f13/wasteland)
+"sSL" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "sSU" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#d9b51c"
@@ -55252,6 +56522,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/firestation)
+"sUt" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius";
+	name = "vault floor"
+	},
+/area/f13/brotherhood)
 "sUx" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -55518,6 +56794,22 @@
 "taW" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
+"taX" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "tbc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/bed,
@@ -55725,7 +57017,7 @@
 	icon_state = "gibbear1"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "tgy" = (
 /obj/item/wrench{
 	pixel_x = 11;
@@ -56069,6 +57361,34 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tqo" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "tqq" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56156,6 +57476,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"trK" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "trN" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -56345,6 +57671,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tvK" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "tvT" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_heater,
@@ -56589,7 +57920,7 @@
 /obj/structure/flora/timber,
 /obj/structure/flora/tallgrass1,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "tBi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -56710,10 +58041,17 @@
 /turf/open/water,
 /area/f13/wasteland)
 "tDy" = (
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/random/low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "tDz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -56896,6 +58234,17 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"tHV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "tIc" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -57087,6 +58436,13 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"tMb" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "tMi" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -57318,6 +58674,13 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"tRj" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "tRk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -57506,6 +58869,10 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
+"tVu" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/mineral/concrete,
+/area/f13/brotherhood)
 "tVG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -57778,6 +59145,25 @@
 	icon_state = "plating"
 	},
 /area/f13/village)
+"udm" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/suit/hooded/surgical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "ueb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -58000,6 +59386,14 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/museum)
+"uiW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "uiX" = (
 /obj/effect/overlay/junk/oldpipes{
 	layer = 2
@@ -58076,6 +59470,11 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ulR" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "ulY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -58386,6 +59785,11 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/village)
+"uuK" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "uuP" = (
 /obj/item/storage/bag/plants,
 /obj/item/trash/f13/k_ration,
@@ -58450,8 +59854,8 @@
 /area/f13/wasteland)
 "uwh" = (
 /obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/river,
+/area/f13/brotherhood)
 "uwj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -58574,6 +59978,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
+"uyu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "uyY" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 4
@@ -58898,7 +60307,7 @@
 "uFx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "uFK" = (
 /obj/structure/barricade/wooden{
 	plane = -6
@@ -59561,6 +60970,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uVn" = (
+/obj/structure/closet/fridge/standard,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "uVt" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -59667,6 +61080,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/caves)
+"uXa" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "uXt" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -59996,6 +61416,17 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"vfQ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/foodspawner/prewar,
+/obj/effect/spawner/lootdrop/f13/foodspawner/prewar,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/brotherhood)
+"vgm" = (
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "vgJ" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibup1"
@@ -60268,6 +61699,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"vnO" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "vnP" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -60449,6 +61883,12 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/carpet,
 /area/f13/building)
+"vrN" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "vsb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -60472,6 +61912,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"vsn" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "vsw" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -60482,13 +61934,19 @@
 "vsR" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/area/f13/brotherhood)
 "vtq" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/massfusion)
+"vts" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vtv" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -60714,6 +62172,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vyW" = (
+/obj/structure/flora/grass/coyote/twentyfive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"vyX" = (
+/obj/item/flag/bos,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"vzm" = (
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/outside/river,
+/area/f13/brotherhood)
 "vzr" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -61221,6 +62694,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"vNZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vOs" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
@@ -61433,6 +62912,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vSL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "vSM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -61458,14 +62942,11 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "vTa" = (
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_y = 7
+/obj/machinery/sleeper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/brotherhood)
 "vTf" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -61483,6 +62964,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vTN" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "vTP" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt,
@@ -61497,6 +62985,12 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vUO" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "vUP" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -61548,6 +63042,15 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"vWM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "vWT" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -61574,6 +63077,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"vXD" = (
+/obj/structure/fence/door,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "vXG" = (
 /obj/structure/sign/map/right{
 	pixel_y = 30
@@ -61711,12 +63218,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"waP" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "waZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/hospital)
+"wbl" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "wbm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -61741,6 +63277,15 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"wci" = (
+/obj/effect/landmark/start/f13/paladin,
+/obj/effect/landmark/start/f13/seniorknight,
+/obj/effect/landmark/start/f13/seniorpaladin,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "wct" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag/towel,
@@ -61920,12 +63465,9 @@
 	},
 /area/f13/building)
 "wfO" = (
-/obj/structure/bed/mattress{
-	pixel_x = 7;
-	pixel_y = 12
-	},
+/obj/structure/shelf_wood,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/brotherhood)
 "wfZ" = (
 /obj/structure/junk/machinery,
 /turf/open/indestructible/ground/outside/dirt{
@@ -62101,6 +63643,15 @@
 	icon_state = "horizontalinnermainleft"
 	},
 /area/f13/wasteland)
+"wka" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "wkb" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -62114,6 +63665,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"wkP" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/ballistic/shotgun/hunting,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "wkV" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -62173,7 +63731,7 @@
 	pixel_x = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "wmN" = (
 /mob/living/simple_animal/hostile/raider/firefighter{
 	name = "City Boys Raider"
@@ -62916,7 +64474,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "wFb" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 9
@@ -63528,6 +65086,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wUj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "wUo" = (
 /obj/structure/barricade/wooden,
 /obj/structure/sign/radiation_l,
@@ -63665,6 +65231,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wXj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood)
 "wXp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -63856,6 +65431,15 @@
 	icon_state = "shadowright"
 	},
 /area/f13/building)
+"xbZ" = (
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "xce" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -63891,6 +65475,35 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"xcB" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "xcF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -64110,6 +65723,12 @@
 	name = "rocky dirt"
 	},
 /area/f13/wasteland)
+"xgT" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "xhd" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -64216,6 +65835,17 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"xjV" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xkf" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -64275,6 +65905,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
+"xmK" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "xmP" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -64456,6 +66093,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/city)
+"xqs" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xqt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -64530,6 +66173,21 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"xsm" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood)
 "xsw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -64538,6 +66196,14 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
+"xsx" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "xsF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -64605,6 +66271,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"xtM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/brotherhood)
 "xtY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/securedoor/legion,
@@ -64644,7 +66317,7 @@
 "xuy" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "xuD" = (
 /obj/effect/decal/cleanable/oil/streak{
 	pixel_x = -10
@@ -64898,10 +66571,11 @@
 	},
 /area/f13/building/museum)
 "xzB" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "xzO" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -64919,6 +66593,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xAc" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "xAp" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -65266,6 +66949,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xHy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xHH" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -65401,6 +67093,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"xKX" = (
+/obj/structure/chair/bench,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "xLa" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -65521,6 +67217,13 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"xOl" = (
+/obj/structure/curtain,
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xOw" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
@@ -65616,6 +67319,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"xQN" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xQT" = (
 /obj/structure/closet,
 /obj/item/geiger_counter,
@@ -65730,12 +67437,23 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"xTm" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "xTy" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/village)
+"xTB" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "xTE" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/road{
@@ -97026,13 +98744,13 @@ aae
 aaB
 aaB
 aae
-aae
-aaA
-aaB
-aaB
-aaB
-aaB
-aaB
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
 aae
 aae
 aae
@@ -97283,13 +99001,13 @@ aae
 aaB
 aae
 aae
-aae
-aaB
+pxe
 aaK
-bjo
-bjo
-aae
-aae
+tHV
+qwe
+ghW
+fIY
+pxe
 aaa
 aaa
 aaa
@@ -97540,29 +99258,29 @@ aae
 aaB
 aae
 aae
-aae
-aaB
-bjo
-aae
-vGl
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+oHF
+tHV
+abg
+otY
+wka
+jcI
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
 aaa
-aae
-aae
-aak
-aak
+aaa
+aaa
 aae
 aae
 aaD
@@ -97797,29 +99515,29 @@ aae
 asA
 aae
 aae
-aae
-aaC
-bjo
-aae
-vGl
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+vTN
+tHV
+eSe
+drq
+wci
+rDz
+gJm
+jbk
+jbk
+jbk
+xcB
+vNZ
+oYF
+ivn
+pxe
+nLN
+eOO
+gOT
+pxe
+pxe
+pxe
+pxe
 aae
 aae
 aaD
@@ -98054,29 +99772,29 @@ aae
 aae
 aae
 aak
-aae
+pxe
 raI
-aaB
-aaa
-aae
-aae
-asS
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aae
-aae
+owY
+xHy
+xHy
+xHy
+eaF
+dgg
+syf
+syf
+dBH
+vts
+vNZ
+oYF
+xqs
+pxe
+mjc
+fId
+fId
+kOC
+fId
+fId
+ocK
 aae
 aae
 aae
@@ -98311,29 +100029,29 @@ aae
 aae
 aae
 aak
-aae
-aaA
-vGl
-vGl
-aak
-aak
-qeC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aae
-aae
+pxe
+eAo
+bCg
+tDy
+aaC
+iFl
+pxe
+hCt
+oYF
+oYF
+dgg
+dgg
+vNZ
+oYF
+sfd
+dxu
+fId
+fId
+fId
+dwu
+sUt
+lGy
+pxe
 aak
 aak
 aak
@@ -98568,30 +100286,30 @@ aae
 aak
 aak
 aae
-vGl
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+tVu
+waP
+nzE
+cqf
+drq
+iwX
+eEQ
+vyX
+oYF
+oYF
+dgg
+bOK
+naO
+soF
+ihK
+rDz
+fId
+fId
+fId
+dwu
+nYh
+nYh
+pxe
 aaa
-aae
-aaB
 aae
 aak
 aae
@@ -98825,30 +100543,30 @@ aaa
 aaa
 aaa
 aaa
-aae
-aae
-aak
-aak
-aak
-aak
-qeC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+tqo
+nzE
+kMM
+drq
+sSL
+eEQ
+fIQ
+nrV
+nrV
+qKq
+ecz
+oYF
+oYF
+mcP
+oxZ
+fId
+fId
+fId
+kOC
+fId
+fId
+pxe
 aaa
-aak
-aaB
 acr
 aae
 aaB
@@ -99082,32 +100800,32 @@ aak
 aae
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-pmP
-pmP
-qeC
-qeC
-qeC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+fYu
+nzE
+wkP
+drq
+onr
+eEQ
+jbk
+jbk
+jbk
+jbk
+xcB
+oYF
+oYF
+ivn
+pxe
+dCm
+fId
+fId
+dwu
+sUt
+lGy
+pxe
 aaa
 aae
-aaB
-aaB
-aaB
+aae
 aaY
 aae
 aae
@@ -99339,32 +101057,32 @@ aae
 aae
 aae
 aae
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-pmP
-pmP
-qeC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+hmK
+xjV
+drq
+drq
+aXS
+pxe
+xcB
+nmm
+nmm
+nmm
+nmm
+oYF
+oYF
+abI
+pxe
+fId
+fId
+fYH
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
 aaa
-aae
-aae
-aaB
-aaB
 aaB
 aae
 aae
@@ -99596,32 +101314,32 @@ aae
 aae
 aae
 aae
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-pmP
-qeC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
+eEQ
+pxe
+pxe
+pxe
+pxe
+pxe
+xbZ
+xbZ
+pxe
+pxe
+mjc
+fId
+fId
+xOl
+hEc
+fId
+fId
+fId
+pxe
 aaa
-aak
-aae
-aae
-aaB
 aaB
 aae
 aak
@@ -99854,31 +101572,31 @@ aae
 aae
 aae
 aak
-aak
-aak
-aak
-aak
-pmP
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+dBK
+dHx
+gZN
+gZN
+kWx
+vSL
+qNs
+nuO
+gZN
+gZN
+dHx
+xgT
+dPv
+pxe
+hGd
+fId
+fId
+fId
+xOl
+udm
+fId
+sAm
+oUq
+pxe
 aaa
-aae
-aae
-aae
-aae
 aaB
 aaB
 aaB
@@ -100111,31 +101829,31 @@ aae
 aae
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+gZN
+gZN
+gZN
+gZN
+xmK
+xmK
+gZN
+gZN
+gZN
+gZN
+xgT
+dPv
+pxe
+fzD
+fId
+fId
+fId
+xOl
+nRn
+cup
+nCw
+fId
+oca
 aaa
-aak
-aae
-aae
-aae
 aaB
 aak
 aaB
@@ -100368,31 +102086,31 @@ aae
 aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+nse
+nDX
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+kZn
+fId
+fId
+fId
+oxZ
+rZY
+fId
+fId
+fId
+pxe
 aaa
-aae
-aae
-aak
-aae
 aaB
 aae
 aak
@@ -100625,31 +102343,31 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+oRb
+pKs
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+vWM
+fJT
+fId
+fId
+pxe
+efh
+mqe
+fId
+vTa
+pxe
 aaa
-aae
-aae
-aak
-aae
 aae
 aak
 aak
@@ -100882,31 +102600,31 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+pUx
+pKs
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+kZn
+fId
+fId
+mjc
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
 aaa
-aae
-aaB
-aae
-aae
 aak
 aae
 aae
@@ -101139,31 +102857,31 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+oRb
+pKs
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+pcP
+fId
+fId
+oUq
+pxe
 aae
 aae
 aae
 aae
 aae
 aaa
-aaB
-ahC
-aaB
-aae
 aae
 aae
 aaB
@@ -101396,31 +103114,31 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+oRb
+pKs
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+kPp
+fId
+fId
+fId
+pxe
 aaa
-gca
-aaB
-all
-acr
+aaa
+aaa
+aaa
+aaa
+gmV
 aae
 aae
 aaB
@@ -101653,25 +103371,25 @@ aae
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+oRb
+osD
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+ozY
+fId
+fId
+fId
+pxe
 aae
 aaa
 aae
@@ -101910,25 +103628,25 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+oRb
+pKs
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+eEQ
+wUj
+vsn
+vsn
+vrN
+pxe
 aae
 aae
 aak
@@ -102167,25 +103885,25 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+xKX
+gTZ
+gTZ
+jMY
+pJu
+hZy
+xKX
+gTZ
+gTZ
+jMY
+xgT
+dPv
+pxe
+okx
+fId
+fId
+fId
+pxe
 aae
 aaa
 aak
@@ -102424,25 +104142,25 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+gZN
+gZN
+gZN
+gZN
+gZN
+gZN
+gZN
+gZN
+gZN
+gZN
+xgT
+dPv
+eEQ
+wXj
+trK
+fId
+fId
+pxe
 aae
 aaa
 aae
@@ -102681,25 +104399,25 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hgS
+dHx
+gZN
+gZN
+uVn
+uVn
+qVg
+qVg
+gZN
+gZN
+dHx
+xgT
+dPv
+eEQ
+dBo
+ddA
+adb
+fId
+pxe
 aae
 aae
 aaa
@@ -102938,25 +104656,25 @@ aak
 aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+uuK
+cAk
+cAk
+hgS
+hgS
+hgS
+hgS
+hgS
+hgS
+hgS
+dBK
+xgT
+dPv
+pxe
+pxe
+pxe
+pxe
+pxe
+pxe
 aae
 aae
 aae
@@ -103198,16 +104916,16 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bYi
+bYi
+bYi
+bYi
+bYi
+bYi
+rxE
+fzB
+xgT
+mes
 aae
 aae
 aae
@@ -103455,6 +105173,16 @@ aae
 aae
 aae
 aak
+vzm
+nyE
+nyE
+nyE
+nyE
+nyE
+rxE
+fzB
+xgT
+mes
 aae
 aae
 aae
@@ -103463,17 +105191,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
 aae
 aae
 aae
@@ -103712,16 +105430,16 @@ aak
 aae
 aak
 aae
-kOC
-cPG
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+vzm
+nyE
+nyE
+nyE
+nyE
+nyE
+rxE
+fzB
+xgT
+mes
 aae
 aae
 aae
@@ -103969,22 +105687,22 @@ aae
 aae
 aae
 aae
-xLC
-xLC
-tPB
-tPB
-tPB
-tPB
+vzm
+nyE
+nyE
+nyE
+nyE
+nyE
 abp
 boC
-eBH
-xLC
-xLC
-aOk
-aOk
-aOk
-tPB
-tPB
+xgT
+dPv
+mSr
+mSr
+mSr
+mSr
+qvQ
+qvQ
 aae
 aae
 aae
@@ -104218,31 +105936,31 @@ aaa
 (148,1,1) = {"
 aaa
 aae
-aae
-rkl
-rkl
-rkl
-rkl
-aae
-aae
-aae
-xLC
-pzs
-tPB
-tPB
-tPB
-tPB
+pxe
+pxe
+pxe
+pxe
+ocK
+pxe
+pxe
+pxe
+vzm
+nyE
+nyE
+nyE
+nyE
+nyE
 gvN
-aOk
-eBH
-naO
+mSr
+xgT
+dPv
 hBx
-aOk
-aOk
-aOk
+fzB
+fzB
+fzB
 qhg
-xLC
-hEu
+vnO
+qrD
 aae
 aaa
 aae
@@ -104475,31 +106193,31 @@ aaa
 (149,1,1) = {"
 aaa
 aae
-aae
-rkl
+pxe
+ohC
 fhn
 blR
-rkl
-aae
-aae
-vGl
-xLC
-qLb
-tPB
-tPB
-tPB
-tPB
-xOD
-aOk
-fyR
-eNJ
-lQR
-aOk
-aOk
-aOk
-eBH
-xLC
-xLC
+kUZ
+taX
+acE
+pxe
+pxe
+nyE
+nyE
+nyE
+nyE
+nyE
+xsx
+mSr
+xgT
+dPv
+mSr
+fzB
+fzB
+fzB
+xgT
+vnO
+vnO
 aae
 aaa
 aae
@@ -104732,31 +106450,31 @@ aaa
 (150,1,1) = {"
 aaa
 aae
-aae
-rkl
-fJT
-xyU
-rkl
-aae
-aae
-vGl
-jxM
-jxM
-tPB
-tPB
-tPB
+pxe
+oYF
+oYF
+oYF
+oYF
+oYF
+oYF
+bEy
+pxe
+pxe
+nyE
+nyE
+nyE
 uwh
-xOD
-aOk
-aOk
-aOk
-aOk
-nWp
-oiD
-oiD
-iXx
-sEB
-xcW
+xsx
+mSr
+xgT
+dPv
+mSr
+mFo
+iOf
+iOf
+wbl
+pNM
+kpw
 aae
 aaa
 aae
@@ -104988,32 +106706,32 @@ aaa
 "}
 (151,1,1) = {"
 aaa
-aae
-aae
-rkl
-rkl
+pxe
+pxe
+oYF
+iOo
 gWQ
-rkl
-rkl
-rkl
-aae
-xLC
-odm
-tGh
-nzE
-xLC
-xLC
-eLQ
-biO
-cFK
-cFK
-aOk
-eBH
+oYF
+gWQ
+oYF
+oYF
+uXa
+pxe
+xtM
+php
+php
+php
+cPG
+ceg
+ocl
+itC
+fzB
+xgT
 fHW
-alW
-alW
-alW
-alW
+bYi
+bYi
+bYi
+bYi
 aae
 aae
 aaa
@@ -105245,28 +106963,28 @@ aaa
 "}
 (152,1,1) = {"
 aaa
-aae
-aae
-rkl
-dBH
-xyU
-xyU
-xyU
-rkl
-aae
-coL
-xLC
-xLC
-xLC
-hEu
-hzN
-lQR
-cFK
-aOk
-aOk
-aOk
-eBH
-nCn
+pxe
+oNv
+oYF
+oYF
+oYF
+oYF
+dRl
+oYF
+oYF
+vgm
+pxe
+jra
+jra
+tRj
+vUO
+pOm
+acG
+xgT
+dPv
+fzB
+xgT
+rxE
 hAE
 hAE
 nQq
@@ -105502,32 +107220,32 @@ aaa
 "}
 (153,1,1) = {"
 aaa
-aae
-aae
-rkl
-pgO
-xzB
-xyU
-xyU
-ffb
-aae
-aae
-aae
-eNJ
+pxe
+xQN
+gWQ
+oYF
+gWQ
+oYF
+gWQ
+oYF
+oYF
+iml
+vXD
+acc
 ptM
-eNJ
-lQR
-biO
-cFK
-aOk
+acc
+lpN
+elE
+eUt
+xgT
 puj
-aOk
+fzB
 qGu
 lRL
-xLC
-xLC
-xLC
-xLC
+vnO
+vnO
+vnO
+vnO
 aae
 aae
 aaa
@@ -105759,30 +107477,30 @@ aaa
 "}
 (154,1,1) = {"
 aaa
-aae
-aae
-rkl
-xyU
-pgO
-nIo
-xyU
+pxe
+iSZ
+oYF
+oYF
+oYF
+oYF
+oYF
 ffb
-abg
-aaB
-aaB
-aOk
-aOk
-aOk
-aOk
-aOk
-cFK
-cFK
-nHY
-etg
-aOk
+oYF
+iml
+pxe
+fzB
+fzB
+fzB
+fzB
+fzB
+eUt
+ocl
+lCq
+llg
+fzB
 abj
-xLC
-xLC
+vnO
+vnO
 pKu
 qPG
 aae
@@ -106016,32 +107734,32 @@ aaa
 "}
 (155,1,1) = {"
 aaa
-aae
-aae
-rkl
-sAm
-tDy
-lxR
-xyU
+pxe
+pmI
+gWQ
+oYF
+gWQ
+oYF
+gWQ
+oYF
+oYF
+iml
+pxe
+qbF
+mSr
+fzB
+fzB
+fzB
+fzB
+evU
+riV
+fzB
+vsR
+vsR
+vsR
 nzb
-abI
-aaB
-aaB
-oJW
-aOk
-aOk
-aOk
-aOk
-aOk
-etg
-etg
-aOk
-vsR
-vsR
-vsR
-rkl
-rkl
-rkl
+nzb
+nzb
 aae
 aHE
 aaa
@@ -106273,32 +107991,32 @@ aaa
 "}
 (156,1,1) = {"
 aaa
-aae
-aae
-rkl
-xyU
-pgO
-xyU
-xyU
-ral
-abI
-aaB
-aaB
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+pxe
+lXK
+dze
+oYF
+oYF
+oYF
+oYF
+oYF
+xsm
+pxe
+pxe
+ack
+mSr
+fzB
+fzB
+fzB
+fzB
+xgT
+dPv
+fzB
 dim
 fAT
-xyU
+gZN
 wfO
-xyU
-rkl
+kHE
+nzb
 aae
 aae
 aaa
@@ -106530,32 +108248,32 @@ aaa
 "}
 (157,1,1) = {"
 aaa
-aae
-aae
-acl
-mqy
-xyU
+pxe
+oYF
+tMb
+oYF
+nja
 mbr
-xyU
-ral
-afn
-abu
-rkl
+pRr
+nJS
+pxe
+pxe
+qvQ
+ack
 mSr
-mSr
-aOk
-nWp
-oiD
-oiD
-lRa
-aOk
-aOk
+fzB
+mFo
+iOf
+iOf
+wbl
+dPv
+fzB
 ral
-kVQ
-kVQ
-kVQ
+pzs
+pzs
+uyu
 qIN
-rkl
+nzb
 aae
 aae
 aae
@@ -106787,32 +108505,32 @@ aaa
 "}
 (158,1,1) = {"
 aaa
-aae
-aak
-acl
-acl
-rkl
-rkl
-rkl
-mSr
-aae
-uFx
-acc
+pxe
+pxe
+pxe
+pxe
+pxe
+ocK
+pxe
+pxe
+pxe
+qvQ
+qvQ
 ack
-vsR
-aOk
-eBH
-xLC
-xLC
-eEQ
+mSr
+fzB
+xgT
+vnO
+vnO
+vnO
 sJn
-biO
+elE
 qcV
-xyU
-xyU
+gZN
+gZN
 bOb
-kVQ
-rkl
+uiW
+nzb
 aae
 aae
 aae
@@ -107053,23 +108771,23 @@ aae
 aae
 aae
 aae
-rkl
-vTa
-fFf
-ral
-aOk
-eBH
-xLC
-xLC
-xLC
-xOD
-fYH
+qvQ
+qvQ
+ack
+mSr
+fzB
+xgT
+vnO
+vnO
+vnO
+dPv
+eUt
 fck
 qQY
-rkl
+nzb
 uFx
-rkl
-rkl
+nzb
+nzb
 aae
 aae
 aae
@@ -107310,20 +109028,20 @@ aae
 aae
 aae
 aae
-uFx
 qvQ
-acE
-mjc
-aOk
+qvQ
+ack
+mSr
+fzB
 nCh
-xLC
-hEu
-xLC
-pRr
-aOk
-aOk
-aOk
-nWp
+vnO
+qrD
+vnO
+dPv
+fzB
+fzB
+fzB
+mFo
 vGl
 aae
 aae
@@ -107567,22 +109285,22 @@ aae
 aae
 aae
 aae
-rkl
-hgS
-adb
-ral
-aOk
-eBH
-tuQ
-xLC
+qvQ
+qvQ
+ack
+mSr
+fzB
+xgT
+mIe
+vnO
 qLb
-mUN
-oiD
-oiD
-oiD
-iXx
-amN
-pzs
+lxR
+iOf
+iOf
+all
+oIN
+kYL
+qvQ
 aae
 aae
 aae
@@ -107824,22 +109542,22 @@ aae
 aae
 aae
 aae
-rkl
-rkl
-rxE
-evU
+qvQ
+qvQ
+ack
+mSr
 xuy
-eBH
-xLC
-xLC
-xLC
-xLC
-xLC
-xLC
-hzN
-eNJ
-eNJ
-eNJ
+xgT
+vnO
+vnO
+vnO
+vnO
+vnO
+vnO
+all
+oIN
+cAi
+qvQ
 aae
 aae
 aae
@@ -108083,21 +109801,21 @@ aae
 aae
 aae
 aae
-vGl
+ack
 alE
-aOk
-eBH
-xLC
+fzB
+xgT
+tvK
 iHZ
-sEB
-xLC
-xLC
-hzN
-lQR
-aOk
-oJW
-cAi
-aOk
+vfQ
+vnO
+vnO
+ulR
+all
+oIN
+gSy
+fzB
+mFC
 aae
 aae
 aae
@@ -108339,24 +110057,24 @@ aae
 aae
 aae
 aae
-aOk
-aOk
-aOk
-aOk
+fzB
+fzB
+fzB
+fzB
 ovv
 pFr
 eDQ
-xLC
-amN
+nyr
+hBj
 wEQ
 gyM
-aOk
-aOk
-rCm
-aOk
+all
+sio
+xAc
+fzB
 mFC
-hyv
-aOk
+qZU
+paC
 biO
 kFs
 kFs
@@ -108595,25 +110313,25 @@ aae
 aae
 vGl
 aae
-aOk
-kLG
-aOk
-aOk
-nWp
-iXx
-xLC
+fzB
+hVd
+fzB
+fzB
+mFo
+wbl
+cLb
 nTn
-hEu
-amN
-xOD
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+quz
+hBj
+dPv
+fzB
+all
+oIN
+cAi
+fzB
+mFC
+ack
+fzB
 biO
 biO
 kFs
@@ -108850,27 +110568,27 @@ aae
 aae
 aae
 vGl
-hkV
+bDn
 mgu
-aOk
-kFs
-aOk
-aOk
-eBH
-xLC
-uFw
-xLC
-xLC
-amN
-mXz
-lRa
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+fzB
+mSr
+fzB
+fzB
+xgT
+vnO
+xTm
+vnO
+vnO
+hBj
+eHm
+xzB
+all
+oIN
+cAi
+fzB
+fzB
+ahC
+fzB
 aOk
 aOk
 aOk
@@ -109110,24 +110828,24 @@ aae
 ejf
 tgs
 wmc
-kFs
-aOk
-aOk
-eBH
-xLC
+mSr
+fzB
+fzB
+xgT
+vnO
 aae
-dJl
-xLC
-xLC
-qEe
-mXz
-lRa
-aOk
-aOk
-aOk
-aOk
-aOk
-aOk
+xTB
+gyt
+vnO
+nCT
+eHm
+all
+oIN
+cAi
+fzB
+mFC
+ack
+fzB
 aOk
 aOk
 aOk
@@ -109365,26 +111083,26 @@ aae
 aae
 aae
 mgu
-aOk
-aOk
-kFs
-aOk
-aOk
-eBH
+fzB
+fzB
+mSr
+fzB
+fzB
+xgT
 vGl
 aae
 aae
 aae
-aSG
-xLC
-coL
-mUN
-lRa
-aOk
-aOk
+jPz
+vnO
+vyW
+lxR
+lIF
+fzB
+fzB
 mFC
-hyv
-aOk
+qZU
+fzB
 oJW
 aOk
 aOk
@@ -109623,10 +111341,10 @@ aae
 aae
 aae
 vGl
-iAq
-aOk
-aOk
-aOk
+nIo
+fzB
+fzB
+fzB
 aae
 aae
 aae
@@ -109637,10 +111355,10 @@ aae
 vGl
 vGl
 aae
-aae
-hZy
-aOk
-vGl
+qvQ
+qvQ
+mFC
+dGR
 hTq
 aOk
 aOk
@@ -109881,7 +111599,7 @@ aae
 aae
 aae
 evb
-qME
+nPn
 tBg
 vGl
 aae

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -675,9 +675,8 @@ obj/effect/landmark/start/f13/ncrlogisticsofficer
 	name = "Senior Scribe"
 	icon_state = "Scribe"
 
-
 /obj/effect/landmark/start/f13/paladincommander
-	name = "Paladin Commander"
+	name = "Head Paladin"
 	icon_state = "Paladin"
 
 /obj/effect/landmark/start/f13/knightcap
@@ -685,7 +684,7 @@ obj/effect/landmark/start/f13/ncrlogisticsofficer
 	icon_state = "Knight"
 
 /obj/effect/landmark/start/f13/seniorknight
-	name = "Knight-Sergeant"
+	name = "Senior Knight"
 	icon_state = "Knight"
 
 /obj/effect/landmark/start/f13/seniorpaladin

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1439,4 +1439,62 @@ list(/obj/item/stack/sheet/metal = 20,
 	desc = "a box!"
 	component_type = /datum/component/storage/concrete/box/debug/tiny_volume_four_item
 
+/* Blueprints for the BOS.*/
 
+/obj/item/storage/box/bos
+	name = "Knight Blueprints"
+	desc = "A box used by the BoS to store Blueprints."
+	
+/obj/item/storage/box/bos/PopulateContents()
+	for(var/i in 1 to 2)
+		var/randomgun = pick(
+							/obj/item/book/granter/crafting_recipe/blueprint/trailcarbine,
+							/obj/item/book/granter/crafting_recipe/blueprint/smg10mm,
+							/obj/item/book/granter/crafting_recipe/blueprint/scoutcarbine,
+							/obj/item/book/granter/crafting_recipe/blueprint/deagle,
+							/obj/item/book/granter/crafting_recipe/blueprint/marksman,
+							/obj/item/book/granter/crafting_recipe/blueprint/pps
+							)
+		new randomgun(src)
+
+/obj/item/storage/box/bos/senior
+	name = "Senior Knight Blueprints"
+	desc = "A box used by the BoS to store Blueprints. This one seems robust."
+	
+/obj/item/storage/box/bos/PopulateContents()
+	for(var/i in 1 to 2)
+		var/randomgun = pick(
+							/obj/item/book/granter/crafting_recipe/blueprint/magnum_revolver,
+							/obj/item/book/granter/crafting_recipe/blueprint/r82,
+							/obj/item/book/granter/crafting_recipe/blueprint/r84,
+							/obj/item/book/granter/crafting_recipe/blueprint/armalite,
+							/obj/item/book/granter/crafting_recipe/blueprint/leveraction,
+							/obj/item/book/granter/crafting_recipe/blueprint/sniper
+							)
+		new randomgun(src)	
+
+/obj/item/storage/box/bos/scribe
+	name = "Scribe Blueprints"
+	desc = "A box used by the BoS to store Blueprints."
+	
+/obj/item/storage/box/bos/PopulateContents()
+	for(var/i in 1 to 2)
+		var/randomgun = pick(
+							/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
+							/obj/item/book/granter/crafting_recipe/blueprint/lightplasmapistol,
+							/obj/item/book/granter/crafting_recipe/blueprint/aer9/focused
+							)
+		new randomgun(src)
+
+/obj/item/storage/box/bos/scribe/senior
+	name = "Senior Scribe Blueprints"
+	desc = "A box used by the BoS to store Blueprints. This one seems robust."
+	
+/obj/item/storage/box/bos/PopulateContents()
+	for(var/i in 1 to 2)
+		var/randomgun = pick(
+							/obj/item/book/granter/crafting_recipe/blueprint/tribeam,
+							/obj/item/book/granter/crafting_recipe/blueprint/rcw,
+							/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle
+							)
+		new randomgun(src)	

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1461,8 +1461,8 @@ list(/obj/item/stack/sheet/metal = 20,
 	name = "Senior Knight Blueprints"
 	desc = "A box used by the BoS to store Blueprints. This one seems robust."
 	
-/obj/item/storage/box/bos/PopulateContents()
-	for(var/i in 1 to 2)
+/obj/item/storage/box/bos/senior/PopulateContents()
+	for(var/i in 1 to 3)
 		var/randomgun = pick(
 							/obj/item/book/granter/crafting_recipe/blueprint/magnum_revolver,
 							/obj/item/book/granter/crafting_recipe/blueprint/r82,
@@ -1477,7 +1477,7 @@ list(/obj/item/stack/sheet/metal = 20,
 	name = "Scribe Blueprints"
 	desc = "A box used by the BoS to store Blueprints."
 	
-/obj/item/storage/box/bos/PopulateContents()
+/obj/item/storage/box/bos/scribe/PopulateContents()
 	for(var/i in 1 to 2)
 		var/randomgun = pick(
 							/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
@@ -1490,7 +1490,7 @@ list(/obj/item/stack/sheet/metal = 20,
 	name = "Senior Scribe Blueprints"
 	desc = "A box used by the BoS to store Blueprints. This one seems robust."
 	
-/obj/item/storage/box/bos/PopulateContents()
+/obj/item/storage/box/bos/scribe/senior/PopulateContents()
 		var/randomgun = pick(
 							/obj/item/book/granter/crafting_recipe/blueprint/tribeam,
 							/obj/item/book/granter/crafting_recipe/blueprint/rcw,

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1453,7 +1453,7 @@ list(/obj/item/stack/sheet/metal = 20,
 							/obj/item/book/granter/crafting_recipe/blueprint/scoutcarbine,
 							/obj/item/book/granter/crafting_recipe/blueprint/deagle,
 							/obj/item/book/granter/crafting_recipe/blueprint/marksman,
-							/obj/item/book/granter/crafting_recipe/blueprint/pps
+							/obj/item/book/granter/crafting_recipe/blueprint/pps,
 							)
 		new randomgun(src)
 
@@ -1469,7 +1469,7 @@ list(/obj/item/stack/sheet/metal = 20,
 							/obj/item/book/granter/crafting_recipe/blueprint/r84,
 							/obj/item/book/granter/crafting_recipe/blueprint/armalite,
 							/obj/item/book/granter/crafting_recipe/blueprint/leveraction,
-							/obj/item/book/granter/crafting_recipe/blueprint/sniper
+							/obj/item/book/granter/crafting_recipe/blueprint/sniper,
 							)
 		new randomgun(src)	
 
@@ -1482,7 +1482,7 @@ list(/obj/item/stack/sheet/metal = 20,
 		var/randomgun = pick(
 							/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
 							/obj/item/book/granter/crafting_recipe/blueprint/lightplasmapistol,
-							/obj/item/book/granter/crafting_recipe/blueprint/aer9/focused
+							/obj/item/book/granter/crafting_recipe/blueprint/aer9/focused,
 							)
 		new randomgun(src)
 
@@ -1491,10 +1491,9 @@ list(/obj/item/stack/sheet/metal = 20,
 	desc = "A box used by the BoS to store Blueprints. This one seems robust."
 	
 /obj/item/storage/box/bos/PopulateContents()
-	for(var/i in 1 to 2)
 		var/randomgun = pick(
 							/obj/item/book/granter/crafting_recipe/blueprint/tribeam,
 							/obj/item/book/granter/crafting_recipe/blueprint/rcw,
-							/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle
+							/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle,
 							)
 		new randomgun(src)	

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -612,8 +612,7 @@ Scribe
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/storage/box/bos/scribe = 1
 		)
 
@@ -629,6 +628,21 @@ Scribe
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/scribe = 1
 		)
+
+/datum/outfit/job/bos/f13scribe/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/jet)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/turbo)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/psycho)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/medx)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/medx/chemistry)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
+	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
+	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
+	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
 
 /*
 Senior Knight
@@ -690,8 +704,7 @@ Senior Knight
 	gunsmith_four = TRUE
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/storage/belt/army/assault = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/storage/box/bos/senior = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1,

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -156,23 +156,23 @@ Paladin Commander
 */
 
 /datum/job/bos/f13paladincommander
-	title = "Paladin Commander"
+	title = "Head Paladin"
 	flag = F13PALADINCOMMANDER
 	head_announce = list("Security")
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are the acting field commander until the Brotherhood regains its strength enough to place an Elder for the bunker. You are a veteran of many battles and sorties in pursuit of Brotherhood goals; your only weakness may just be your hubris. Your main goals are defense of the Chapter and surveillance of the surrounding region for technology."
-	supervisors = "the Sentinel"
+	supervisors = "the Elders"
 	selection_color = "#7f8c8d"
 	display_order = JOB_DISPLAY_ORDER_COMMANDER
 	outfit = /datum/outfit/job/bos/f13commander
 	exp_requirements = 2400
-/*
+
 	loadout_options = list(
 	/datum/outfit/loadout/sentheavy, //Gauss + Glock
 	/datum/outfit/loadout/sentmini //Minigun
 	)
-*/
+
 
 	access = list(ACCESS_BROTHERHOOD_COMMAND, ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS, ACCESS_CHANGE_IDS)
 	minimal_access = list(ACCESS_BROTHERHOOD_COMMAND, ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS, ACCESS_CHANGE_IDS)
@@ -211,7 +211,6 @@ Paladin Commander
 	mask = /obj/item/clothing/mask/gas/sechailer
 	ears = /obj/item/radio/headset/headset_bos/command
 	suit = /obj/item/clothing/suit/armor/power_armor/t51b
-	suit_store = /obj/item/gun/energy/laser/aer12
 	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b
 	neck = /obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
@@ -220,10 +219,9 @@ Paladin Commander
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/m10mm/adv/simple = 2,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 6,
-		/obj/item/stock_parts/cell/ammo/mfc = 5
 		)
 
-/*
+
 /datum/outfit/loadout/sentheavy
 	name = "Heavy Paladin Commander"
 	backpack_contents = list(
@@ -236,20 +234,20 @@ Paladin Commander
 	backpack_contents = list(
 		/obj/item/minigunpackbal5mm = 1,
 	)
-*/
+
 
 /*
 Proctor
 */
 
 /datum/job/bos/f13headscribe
-	title = "Proctor"
+	title = "Head Scribe"
 	flag = F13HEADSCRIBE
 	head_announce = list("Security")
 	total_positions = 0
 	spawn_positions = 0
 	description = "You are the foremost experienced scribe remaining in this bunker. Your role is to ensure the safekeeping and proper usage of technology within the Brotherhood. You are also the lead medical expert in this Chapter. Delegate your tasks to your Scribes."
-	supervisors = "the Sentinel"
+	supervisors = "the Elders"
 	selection_color = "#7f8c8d"
 	display_order = JOB_DISPLAY_ORDER_HEADSCRIBE
 	outfit = /datum/outfit/job/bos/f13headscribe
@@ -282,7 +280,7 @@ Proctor
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 
 /datum/outfit/job/bos/f13headscribe
-	name = "Proctor"
+	name = "Head Scribe"
 	jobtype = /datum/job/bos/f13headscribe
 	chemwhiz = TRUE
 	accessory = /obj/item/clothing/accessory/bos/headscribe
@@ -315,7 +313,7 @@ Knight-Captain
 */
 
 /datum/job/bos/f13knightcap
-	title = "Knight-Captain"
+	title = "Knight-Captai"
 	flag = F13KNIGHTCAPTAIN
 	head_announce = list("Security")
 	total_positions = 0
@@ -434,8 +432,8 @@ Paladin
 /datum/job/bos/f13paladin
 	title = "Paladin"
 	flag = F13PALADIN
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are this Chapter's main line of defense and offense; highly trained in combat and weaponry though with little practical field experience, you are eager to prove your worth to the Brotherhood. Your primary duties are defense and surface operations. You may also be assigned a trainee Initiate."
 	supervisors = "the Head and Senior Paladin"
 	display_order = JOB_DISPLAY_ORDER_PALADIN
@@ -509,8 +507,8 @@ Senior Scribe
 /datum/job/bos/f13seniorscribe
 	title = "Senior Scribe"
 	flag = F13SENIORSCRIBE
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are the bunker's seniormost medical and scientific expert in the bunker, sans the Proctor themselves. You are trained in both medicine and engineering, while also having extensive studies of the old world to assist in pinpointing what technology would be useful to the Brotherhood and its interests."
 	supervisors = "the Proctor"
 	display_order = JOB_DISPLAY_ORDER_SENIORSCRIBE
@@ -561,7 +559,8 @@ Senior Scribe
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/reagent_containers/hypospray/CMO = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 7
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 7,
+		/obj/item/storage/box/bos/scribe/senior = 1
 	)
 
 /*
@@ -571,8 +570,8 @@ Scribe
 /datum/job/bos/f13scribe
 	title = "Scribe"
 	flag = F13SCRIBE
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 2
+	spawn_positions = 2
 	description = "You answer to senior members, tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining the brotherhoods scientific archives. You may also be given a trainee to assign duties to."
 	supervisors = "the Head and Senior Scribe"
 	display_order = JOB_DISPLAY_ORDER_SCRIBE
@@ -614,7 +613,8 @@ Scribe
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/gun/energy/laser/pistol = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+		/obj/item/storage/box/bos/scribe = 1
 		)
 
 
@@ -635,10 +635,10 @@ Knight-Sergeant
 */
 
 /datum/job/bos/f13seniorknight
-	title = "Knight-Sergeant"
+	title = "Senior Knight"
 	flag = F13SENIORKNIGHT
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 2
+	spawn_positions = 2
 	description = "You report directly to the Knight-Captain. You are the Brotherhood Knight-Sergeant. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	supervisors = "the Knight-Captain"
 	display_order = JOB_DISPLAY_ORDER_SENIORKNIGHT
@@ -675,10 +675,10 @@ Knight-Sergeant
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/R93)
 
 /datum/outfit/job/bos/f13seniorknight
-	name = "Knight-Sergeant"
+	name = "Senior Knight"
 	jobtype = /datum/job/bos/f13seniorknight
 	suit = /obj/item/clothing/suit/armor/medium/combat/brotherhood/senior
-	suit_store = /obj/item/gun/energy/laser/aer12
+	suit_store = /obj/item/gun/energy/laser/aer9
 	accessory = /obj/item/clothing/accessory/bos/seniorknight
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/sechailer
@@ -693,8 +693,7 @@ Knight-Sergeant
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/storage/belt/army/assault = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
-		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
-		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1,
+		/obj/item/storage/box/bos/senior = 1
 		)
 /*
 /datum/outfit/loadout/sknightb
@@ -731,8 +730,8 @@ Knight
 /datum/job/bos/f13knight
 	title = "Knight"
 	flag = F13KNIGHT
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 3
+	spawn_positions = 3
 	description = "You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	supervisors = "the Head and Knight-Sergeant"
 	display_order = JOB_DISPLAY_ORDER_KNIGHT
@@ -784,7 +783,8 @@ Knight
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 5
+		/obj/item/stock_parts/cell/ammo/mfc = 5,
+		/obj/item/storage/box/bos = 1
 		)
 /*
 /datum/outfit/loadout/knighte
@@ -813,8 +813,8 @@ Initiate
 /datum/job/bos/f13initiate
 	title = "Initiate"
 	flag = F13INITIATE
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 4
+	spawn_positions = 4
 	description = "Either recently inducted or born into the Brotherhood, you have since proven yourself worthy of assignment to the Chapter. You are to assist your superiors and receive training how they deem fit. You are NEVER allowed to leave the bunker without the direct supervision of a superior; doing so may result in exile."
 	supervisors = "the Scribes, Knights, or Paladins"
 	display_order = JOB_DISPLAY_ORDER_INITIATE
@@ -864,7 +864,9 @@ Initiate
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/aer9 = 1,
 		/obj/item/stock_parts/cell/ammo/mfc = 2,
-		/obj/item/clothing/accessory/bos/initiateK = 1
+		/obj/item/clothing/accessory/bos/initiateK = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1
 		)
 
 /datum/outfit/loadout/initiates

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -202,8 +202,8 @@ Paladin Commander
 		H.mind.AddSpell(S)
 
 /datum/outfit/job/bos/f13commander
-	name = "Paladin Commander"
-	jobtype = /datum/job/bos/f13sentinel
+	name = "Head Paladin"
+	jobtype = /datum/job/bos/f13paladincommander
 	uniform = /obj/item/clothing/under/f13/recon
 	belt = /obj/item/storage/belt/army/assault
 	accessory = /obj/item/clothing/accessory/bos/sentinel
@@ -631,7 +631,7 @@ Scribe
 		)
 
 /*
-Knight-Sergeant
+Senior Knight
 */
 
 /datum/job/bos/f13seniorknight
@@ -671,7 +671,6 @@ Knight-Sergeant
 		return
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AER9)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/AEP7)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/dks)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/R93)
 
 /datum/outfit/job/bos/f13seniorknight
@@ -693,7 +692,11 @@ Knight-Sergeant
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/storage/belt/army/assault = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
-		/obj/item/storage/box/bos/senior = 1
+		/obj/item/storage/box/bos/senior = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_three = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_four = 1,
 		)
 /*
 /datum/outfit/loadout/sknightb
@@ -783,7 +786,6 @@ Knight
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_two = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 5,
 		/obj/item/storage/box/bos = 1
 		)
 /*

--- a/code/modules/jobs/job_whitelist.dm
+++ b/code/modules/jobs/job_whitelist.dm
@@ -89,7 +89,9 @@
 		for(var/rtypeWL in GLOB.ncr_rangervet_positions)
 			play_records[rtypeWL] = rtypeWL
 	*/
+	/*
 	if(whitelists["leadership"])
 		for(var/rtypeWL in GLOB.command_positions)
 			play_records[rtypeWL] = rtypeWL
 	prefs.job_whitelists = play_records
+	*/

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -90,12 +90,12 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 //Brotherhood
 GLOBAL_LIST_INIT(brotherhood_positions, list(
 	"Sentinel",
-	"Paladin Commander",
+	"Head Paladin",
 	"Knight-Captain",
 	"Proctor",
 	"Star Paladin",
 	"Paladin",
-	"Knight-Sergeant",
+	"Senior Knight",
 	"Knight",
 	"Senior Scribe",
 	"Scribe",


### PR DESCRIPTION
## About The Pull Request
currently awaiting host approval

reworks BoS slots, power and loadouts to relegate them to being a minor faction with the potential to become a more credible threat the longer the round goes on.

HP: 1
Paladin: 1
SK: 2
Knight: 3
SS: 1
Scribe: 2
Initiate: 4

Only the HP and Paladin spawn with 'good' gear - only the HP had an actual choice in loadouts. The Paladin gets an AER12, the remaining roles get AER9s or AEP7s, or similar sidegrades. RnD has been removed from the Brotherhood.

The current main strength of the BoS lies in their scribes and knights - each role spawns with two random weapon blueprints. Knights spawn with ballistic blueprints, Scribes spawn with energy blueprints. The Senior roles receive better blueprints, with the SS having the rarest due to only being one slot. These blueprints can be used to craft guns, allowing for the BoS to become stronger the more they go out and salvage/scavenge for parts, meaning they can become a threat if left unchecked by the NCR/Legion.

Knights start with basic ballistic blueprints - low-cal SMGs, basic rifles, handguns, that sort of thing.
Senior Knights focus mainly on high-powered ballistics such as shotguns and rifles.
Scribes start with improved energy weapon blueprints.
The Senior Scribe only receives one blueprint, but has access to the strongest (compared to the other blueprints) blueprints.

They also have a new, shiny surface base which isn't Fucking Impenetrable. Yippie.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: the motherfuggin bos 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
