### PR TITLE
Total unarmed balancing + quirk changes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -538,7 +538,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	var/mob/living/carbon/human/H = quirk_holder
 	H.dna.species.punchdamagelow = IRON_FIST_PUNCH_DAMAGE_LOW
 	H.dna.species.punchdamagehigh = IRON_FIST_PUNCH_DAMAGE_MAX
-
+/*
 /datum/quirk/steel_fist
 	name = "Fists of Steel"
 	desc = "You have MASSIVE fists of kung-fury! Even MORE increases unarmed damage."
@@ -552,6 +552,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	var/mob/living/carbon/human/H = quirk_holder
 	H.dna.species.punchdamagelow = STEEL_FIST_PUNCH_DAMAGE_LOW
 	H.dna.species.punchdamagehigh = STEEL_FIST_PUNCH_DAMAGE_MAX
+*/
 
 /datum/quirk/light_step
 	name = "Glass Walker"
@@ -761,6 +762,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	lose_text = span_danger("You know? Being cold kind of sucks actually.")
 	locked =  FALSE
 
+/*
 /* /datum/quirk/radimmune
 	name = "Radiation - Immune"
 	desc = "Gieger Counters are for suckers."
@@ -778,6 +780,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	gain_text = span_notice("You've decided radiation just doesn't matter much.")
 	lose_text = span_danger("You no longer feel like you could roll around in a rad puddle for a while.")
 	locked =  FALSE
+*/
 
 /datum/quirk/radimmunesorta
 	name = "Radiation - Sorta Immune"
@@ -788,6 +791,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	lose_text = span_danger("You no longer think you should hang out next to rad puddles.")
 	locked =  FALSE
 
+/*
 /datum/quirk/nohunger
 	name = "Does not Eat"
 	desc = "You don't need to eat to live, lucky you."
@@ -796,6 +800,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	gain_text = span_notice("Your need for food has left you.")
 	lose_text = span_danger("GOD YOU WANT A BURGER SO BAD.")
 	locked =  FALSE
+*/
 
 /datum/quirk/thickskin
 	name = "Thick Skin"
@@ -833,6 +838,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	lose_text = span_danger("What's a two by four again?")
 	locked =  FALSE
 
+/*
 /datum/quirk/grappler
 	name = "Trained Grappler"
 	desc = "You've got real skills when it comes to grabbing people by the bits!"
@@ -859,6 +865,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	gain_text = span_notice("They are already dead.")
 	lose_text = span_danger("Your fists no longer feel so powerful.")
 	locked =  FALSE
+*/
 
 /datum/quirk/quietstep
 	name = "Quiet Step"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -396,6 +396,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	mood_change = -5
 	timeout = 3 MINUTES
 
+/*
 /datum/quirk/catphobia
 	name = "Phobia - Cats"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with cats."
@@ -631,7 +632,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/eye, TRAUMA_RESILIENCE_ABSOLUTE)
-
+*/
 
 /datum/quirk/mute
 	name = "Mute"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -10,6 +10,7 @@
 	lose_text = span_notice("You can taste again!")
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
 
+/*
 /datum/quirk/no_chocolate
 	name = "Chocolate intolerance"
 	desc = "Your metabolism finds chocolate rather disagreeable."
@@ -18,7 +19,9 @@
 	gain_text = span_notice("You feel like eating chocolate is a bad idea.")
 	lose_text = span_notice("You feel like it's safe to eat chocolate again")
 	medical_record_text = "Patient has an aversion to theobromine, and therefore cannot have chocolate."
+*/
 
+/*
 /datum/quirk/white_woman
 	name = "Peanutbutter difficulties"
 	desc = "Your tongue has difficulty handling the adhesiveness of peanut butter"
@@ -27,6 +30,7 @@
 	gain_text = span_notice("Your tongue lacks the manipulation to properly eat peanut butter.")
 	lose_text = span_notice("Your tongue is skilled at taking on sticky peanut butter.")
 	medical_record_text = "Patient's tongue lacks the dexterity required to eat peanut butter."
+*/
 
 /datum/quirk/autobrew //sugary foods create ethanol
 	name = "Autobrewery syndrome"
@@ -263,6 +267,8 @@
 			species.liked_food |= MEAT
 		if(initial(species.disliked_food) & ~MEAT)
 			species.disliked_food &= ~MEAT
+
+/*
 /datum/quirk/hydra
 	name = "Hydra Heads"
 	desc = "You are a tri-headed creature. To use, format your name like (Rucks-Sucks-Ducks) and use the action button in the top left."
@@ -308,6 +314,8 @@
 	hydra.real_name = selhead
 	hydra.visible_message("<span class='notice'>[hydra.name] pulls the rest of their heads back; and puts [selhead]'s forward.</span>", \
 							"<span class='notice'>You are now talking as [selhead]!</span>", ignored_mobs=owner)
+
+*/
 
 /datum/quirk/sheltered
 	name = "Sheltered"
@@ -372,7 +380,7 @@
 /datum/quirk/smol/remove()
 	if(istype(quirk_holder))
 		quirk_holder.RemoveElement(/datum/element/mob_holder) // undog
-
+/*
 /datum/quirk/cat
 	name = "A cat!"
 	desc = "You identify as a cat! (Mostly to help identify your species mechanically)"
@@ -410,6 +418,7 @@
 	desc = "You identify as a dog! (Mostly to help identify your species mechanically)"
 	value = 0
 	mob_trait = TRAIT_DOG
+*/
 
 /datum/quirk/photographer
 	name = "Photographer"
@@ -455,6 +464,7 @@
 		if(!human_holder.put_in_hands(folder))
 			folder.forceMove(get_turf(human_holder))
 
+/*
 /datum/quirk/zoomies
 	name = "Zoomies"
 	desc = "You can sprint twice as far before you begin to get tired. Just don't run into things."
@@ -466,3 +476,4 @@
 	desc = "You never tire of sprinting at all, just be extremely careful not to run into things."
 	value = 0
 	mob_trait = TRAIT_SUPER_ZOOMIES
+*/

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -675,12 +675,10 @@ obj/item/melee/onehanded/knife/switchblade
 	icon = 'icons/fallout/objects/melee/melee.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
-	attack_speed = CLICK_CD_MELEE * 0.9
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_NONE
-	armour_penetration = 0.05
 	throwforce = 10
 	throw_range = 5
 	attack_verb = list("punched", "jabbed", "whacked")
@@ -697,8 +695,8 @@ obj/item/melee/onehanded/knife/switchblade
 	if(ishuman(user) && slot == SLOT_GLOVES)
 		ADD_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
 		if(HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
-			H.dna.species.punchdamagehigh += force + 8 //Work around for turbo bad code here. Makes this correctly stack with your base damage. No longer makes ghouls the kings of melee.
-			H.dna.species.punchdamagelow += force + 8
+			H.dna.species.punchdamagehigh += force //Work around for turbo bad code here. Makes this correctly stack with your base damage. No longer makes ghouls the kings of melee.
+			H.dna.species.punchdamagelow += force
 			H.dna.species.attack_sound = hitsound
 			if(sharpness == SHARP_POINTY || sharpness ==  SHARP_EDGED)
 				H.dna.species.attack_verb = pick("slash","slice","rip","tear","cut","dice")
@@ -710,9 +708,12 @@ obj/item/melee/onehanded/knife/switchblade
 			H.dna.species.punchdamagehigh = 10
 			H.dna.species.punchdamagelow = 1
 		if(HAS_TRAIT(user, TRAIT_IRONFIST))
+			H.dna.species.punchdamagehigh = 10
+			H.dna.species.punchdamagelow = 4
+		if(HAS_TRAIT(user, TRAIT_STEELFIST))
 			H.dna.species.punchdamagehigh = 12
 			H.dna.species.punchdamagelow = 6
-		if(HAS_TRAIT(user, TRAIT_STEELFIST))
+		if(HAS_TRAIT(user, TRAIT_FEV)) //Holy shit that Supermutant had a powerfist!
 			H.dna.species.punchdamagehigh = 16
 			H.dna.species.punchdamagelow = 10
 		H.dna.species.attack_sound = 'sound/weapons/punch1.ogg'
@@ -755,8 +756,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "spiked"
 	item_state = "spiked"
 	sharpness = SHARP_POINTY
+	armour_penetration = 0.1
 	force = 28
-	armour_penetration = 0.10
 
 // Sappers			Keywords: Damage 27
 /obj/item/melee/unarmed/sappers
@@ -771,7 +772,7 @@ obj/item/melee/onehanded/knife/switchblade
 	. = ..()
 	if(!istype(M))
 		return
-	M.apply_damage(20, STAMINA, "head", M.run_armor_check("head", "melee"))
+	M.apply_damage(10, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
 // Tiger claws		Keywords: Damage 33, Pointy
 /obj/item/melee/unarmed/tigerclaw
@@ -816,7 +817,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "punch_dagger"
 	item_state = "punch_dagger"
 	force = 29
-	armour_penetration = 0.12
+	armour_penetration = 0.1
 	sharpness = SHARP_POINTY
 	attack_verb = list("stabbed", "sliced", "pierced", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -837,7 +838,7 @@ obj/item/melee/unarmed/punchdagger/cyborg
 	slot_flags = ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 35
-	armour_penetration = 1
+	armour_penetration = 0.15
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -676,9 +676,11 @@ obj/item/melee/onehanded/knife/switchblade
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
+	attack_speed = CLICK_CD_MELEE * 0.9
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_NONE
+	armour_penetration = 0.05
 	throwforce = 10
 	throw_range = 5
 	attack_verb = list("punched", "jabbed", "whacked")


### PR DESCRIPTION
## About The Pull Request
Ensures unarmed combat is no longer an instant win. This includes balancing unarmed weaponry and nerfing/removing existing unarmed quirks. 
Removes a bunch of vestigial CB code that have no reason to be in the game.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
del: Removed a shit ton of traits that existed purely for weird furry purposes.
del: Removed VERY easily exploitable traits that will most definitely be abused by the playerbase if it launches.
balance: Rebalanced iron fist, removed a majority of OP unarmed traits from the start menu.
/:cl:
