### PR TITLE
Family Heirloom Tweaks

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -59,54 +59,22 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 /datum/quirk/family_heirloom/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
-	switch(quirk_holder.mind.assigned_role)
-		if("Scribe")
-			heirloom_type = pick(/obj/item/trash/f13/electronic/toaster, /obj/item/screwdriver/crude, /obj/item/toy/tragicthegarnering)
-		if("Knight")
-			heirloom_type = /obj/item/gun/ballistic/automatic/toy/pistol
-		if("BoS Off-Duty")
-			heirloom_type = /obj/item/toy/figure/borg
-		if("Sheriff")
-			heirloom_type = /obj/item/clothing/accessory/medal/silver
-		if("Deputy")
-			heirloom_type = /obj/item/clothing/accessory/medal/bronze_heart
-		if("Texarkana Trade Worker")
-			heirloom_type = /obj/item/coin/plasma
-		if("Town Doctor")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope,/obj/item/toy/tragicthegarnering)
-		if("Senior Doctor")
-			heirloom_type = pick(/obj/item/toy/nuke, /obj/item/wrench/medical, /obj/item/clothing/neck/tie/horrible)
-		if("Prime Legionnaire")
-			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/clothing/accessory/talisman, /obj/item/toy/plush/mr_buckety)
-		if("Recruit Legionnaire")
-			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/clothing/accessory/talisman,/obj/item/clothing/accessory/skullcodpiece/fake)
-		if("Den Mob Boss")
-			heirloom_type = /obj/item/lighter/gold
-		if("Den Doctor")
-			heirloom_type = /obj/item/card/id/dogtag/MDfakepermit
-		if("Farmer")
-			heirloom_type = pick(/obj/item/hatchet, /obj/item/shovel/spade, /obj/item/toy/plush/beeplushie)
-		if("Janitor")
-			heirloom_type = /obj/item/mop
-		if("Security Officer")
-			heirloom_type = /obj/item/clothing/accessory/medal/silver/valor
-		if("Scientist")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
-		if("Assistant")
-			heirloom_type = /obj/item/clothing/gloves/cut/family
-		if("Chaplain")
-			heirloom_type = /obj/item/camera/spooky/family
-		if("Captain")
-			heirloom_type = /obj/item/clothing/accessory/medal/gold/captain/family
+	if(quirk_holder.mind.assigned_role)
+		if(quirk_holder.mind.assigned_role in list("Head Paladin", "Paladin", "Head Knight", "Senior Knight", "Knight", "Senior Scribe", "Scribe", "Initiate"))
+			heirloom_type = pick(/obj/item/card/id/rusted/brokenholodog, /obj/item/trash/f13/electronic/toaster)	
+		if(quirk_holder.mind.assigned_role in list("NCR Captain", "NCR Lieutenant", "NCR Veteran Ranger", "NCR Brahmin Baron", "NCR Ranger", "NCR Heavy Trooper", "NCR Sergeant", "NCR Corporal", "NCR Conscript ", "NCR Trooper", "NCR Military Police", "NCR Rear Echelon"))
+			heirloom_type = pick(/obj/item/melee/onehanded/knife/bayonet, /obj/item/lighter, /obj/item/toy/cards/deck, /obj/item/card/id/rusted)
+		if(quirk_holder.mind.assigned_role in list("Legion Centurion", "Legion Orator", "Legion Veteran Decanus", "Legion Prime Decanus", "Legion Recruit Decanus", "Legion Vexillarius", "Legion Explorer", "Veteran Legionnaire", "Prime Legionnaire", "Recruit Legionnaire", "Legion Slavemaster"))
+			heirloom_type = pick(/obj/item/melee/onehanded/machete, /obj/item/melee/onehanded/club/warclub, /obj/item/card/id/rusted/rustedmedallion, /obj/item/clothing/accessory/talisman,/obj/item/clothing/accessory/skullcodpiece/fake, /obj/item/warpaint_bowl)
 	if(!heirloom_type)
 		heirloom_type = pick(
 		/obj/item/toy/cards/deck,
 		/obj/item/lighter,
 		/obj/item/card/id/rusted,
 		/obj/item/card/id/rusted/fadedvaultid,
+		/obj/item/card/id/rusted/brokenholodog,
+		/obj/item/card/id/rusted/brokenholodog/enclave,
 		/obj/item/clothing/gloves/ring/silver,
-		/obj/item/toy/figure/detective,
-		/obj/item/toy/tragicthegarnering,
 		)
 	heirloom = new heirloom_type(get_turf(quirk_holder))
 	GLOB.family_heirlooms += heirloom


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Makes it so that family heirlooms are for the most part assigned by faction, for now I gave heirloom sets to the three major factions (BoS, NCR, and Legion) and redid the generic heirlooms so that you can additionally get an NCR, Legion, BoS, or Enclave broken ID

### NCR gets either:
- A bayonet knife
- A lighter
- A deck of cards
- A set of rusted dog tags

### BoS gets either:
- A toaster
- A broken holotag

### Legion gets either:
- A machete
- A warclub
- A rusted medalion
- A warpaint bowl
- A false codpiece
- A bone talisman
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked the family heirloom quirk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
