### PR TITLE
legion fixes and more

### DIFF
--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -833,7 +833,7 @@ Mayor
 
 	outfit = /datum/outfit/job/den/f13settler
 
-	/*
+	
 	loadout_options = list(
 		/datum/outfit/loadout/provisioner,
 		/datum/outfit/loadout/groundskeeper,
@@ -842,8 +842,9 @@ Mayor
 		/datum/outfit/loadout/militia,
 		/datum/outfit/loadout/singer,
 		/datum/outfit/loadout/farmer,
-		/datum/outfit/loadout/prospector
-	)*/
+		/datum/outfit/loadout/prospector,
+		/datum/outfit/loadout/remnant
+	)
 	access = list(ACCESS_BAR, ACCESS_TOWN, ACCESS_TOWN_CIV)
 	minimal_access = list(ACCESS_BAR, ACCESS_TOWN, ACCESS_TOWN_CIV)
 	matchmaking_allowed = list(
@@ -902,7 +903,7 @@ Mayor
 		/obj/item/clothing/under/f13/cowboyg,
 		/obj/item/clothing/under/f13/cowboyt)
 
-/*
+
 /datum/outfit/loadout/provisioner
 	name = "Provisioner"
 	neck = /obj/item/clothing/neck/scarf/cptpatriot
@@ -914,12 +915,8 @@ Mayor
 	gloves = /obj/item/clothing/gloves/f13/leather
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	backpack_contents = list(/obj/item/reagent_containers/food/drinks/flask = 1,
-	///obj/item/gun/ballistic/automatic/pistol/n99 = 1,
-	///obj/item/ammo_box/magazine/m10mm/adv/simple = 1,
 	/obj/item/storage/medical/ancientfirstaid = 1,
 	/obj/item/reagent_containers/food/drinks/flask/survival = 1,
-	///obj/item/gun/ballistic/automatic/pistol/n99 = 1,
-	///obj/item/ammo_box/magazine/m10mm/adv/simple = 1
 	)
 
 /datum/outfit/loadout/groundskeeper
@@ -966,8 +963,9 @@ Mayor
 	gloves = /obj/item/clothing/gloves/botanic_leather
 	shoes = /obj/item/clothing/shoes/f13/peltboots
 	backpack_contents = list(
-	///obj/item/gun/ballistic/revolver/winchesterrebored = 1,
-	///obj/item/ammo_box/a762/doublestacked = 2,
+	/obj/item/gun/ballistic/rifle/hunting = 1,
+	/obj/item/ammo_box/a308 = 2,
+	/obj/item/gun_upgrade/scope/watchman = 1,
 	/obj/item/fishingrod = 1,
 	/obj/item/binoculars = 1,
 	/obj/item/crafting/campfirekit = 1,
@@ -983,11 +981,10 @@ Mayor
 	shoes = /obj/item/clothing/shoes/f13/military
 	belt = /obj/item/storage/belt/bandolier
 	backpack_contents = list(
-	///obj/item/ammo_box/a308 = 2,
+	/obj/item/gun/ballistic/automatic/combat/worn = 1,
+	/obj/item/ammo_box/magazine/tommygunm45/stick = 2,
 	/obj/item/shovel/trench =1,
 	/obj/item/binoculars = 1,
-	///obj/item/gun/ballistic/rifle/hunting = 1,
-	/obj/item/gun_upgrade/scope/watchman = 1
 	)
 
 /datum/outfit/loadout/singer
@@ -1001,11 +998,7 @@ Mayor
 	/obj/item/grenade/smokebomb = 2,
 	/obj/item/clothing/accessory/pocketprotector/full = 1,
 	/obj/item/choice_beacon/music = 1,
-	///obj/item/gun/energy/laser/complianceregulator = 1,
-	///obj/item/stock_parts/cell/ammo/ec = 1
 	)
-
-// if we ever add back the loadout display you'll have to put the items in places you want it to appear on the display model
 
 /datum/outfit/loadout/farmer
 	name = "Farmer"
@@ -1036,9 +1029,18 @@ Mayor
 	/obj/item/pickaxe/silver = 1,
 	/obj/item/clothing/glasses/welding = 1,
 	/obj/item/t_scanner/adv_mining_scanner = 1,
-	///obj/item/ammo_box/m44 = 2,
-	///obj/item/gun/ballistic/revolver/m29/snub = 1
-	)*/
+	/obj/item/ammo_box/m44 = 2,
+	/obj/item/gun/ballistic/revolver/m29/snub = 1
+	)
+
+/datum/outfit/loadout/remnant
+	name = "Enclave Remnant"
+	backpack_contents = list(
+	/obj/item/clothing/head/f13/enclave/peacekeeper = 1,
+	/obj/item/card/id/dogtag/enclave/trooper = 1,
+	/obj/item/stock_parts/cell/ammo/ec = 3,
+	/obj/item/gun/energy/laser/pistol/worn = 1,
+	)
 
 /*--------------------------------------------------------------*/
  

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1102,7 +1102,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/paper/natural = 2,
 		/obj/item/pen/fountain = 1,
 		/obj/item/taperecorder = 1,
-		/obj/item/clothing/under/f13/legauxilia = 1
+		/obj/item/clothing/under/f13/legauxilia = 1,
 		/obj/item/stack/f13Cash/random/aureus/high = 2,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -204,9 +204,9 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	minimal_access = list(ACCESS_LEGION, ACCESS_CHANGE_IDS, ACCESS_LEGION_COMMAND)
 
 	loadout_options = list(
-		/datum/outfit/loadout/palacent,		// M1919, CQC
-		/datum/outfit/loadout/rangerhunter,	// Hunting Revolver, AMR, Spatha
-		/datum/outfit/loadout/centurion,	// 14mm Pistol, GOliath
+		/datum/outfit/loadout/palacent,		// BAR
+		/datum/outfit/loadout/rangerhunter,	// Hunting Revolver, Spatha, Unique Sniper
+		/datum/outfit/loadout/centurion,	// 14mm Pistol + Unique Lever-Action
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -248,19 +248,18 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Paladin-Slayer Centurion"
 	suit = /obj/item/clothing/suit/armor/legion/palacent
 	head = /obj/item/clothing/head/helmet/f13/legion/palacent
-	suit_store = /obj/item/gun/ballistic/automatic/m1919
+	suit_store = /obj/item/gun/ballistic/automatic/bar
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/mm308 = 1,
-		/obj/item/book/granter/martial/cqc = 1,
+		/obj/item/ammo_box/magazine/m308/ext = 3,
 		)
 
 /datum/outfit/loadout/rangerhunter
 	name = "Ranger-Hunter Centurion"
 	suit = /obj/item/clothing/suit/armor/legion/rangercent
 	head = /obj/item/clothing/head/helmet/f13/legion/rangercent
-	suit_store = /obj/item/gun/ballistic/rifle/mag/antimateriel
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper/snipervenator
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/amr = 2,
+		/obj/item/ammo_box/magazine/w3006 = 2,
 		/obj/item/ammo_box/c4570 = 3,
 		/obj/item/gun/ballistic/revolver/hunting = 1,
 		/obj/item/melee/onehanded/machete/spatha = 1,
@@ -270,7 +269,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Warlord Centurion"
 	suit = /obj/item/clothing/suit/armor/legion/centurion
 	head = /obj/item/clothing/head/helmet/f13/legion/centurion
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
 	backpack_contents = list(
 		/obj/item/storage/belt/holster = 1,
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,
@@ -297,10 +296,10 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	minimal_access = list(ACCESS_LEGION, ACCESS_CHANGE_IDS, ACCESS_LEGION_COMMAND)
 
 	loadout_options = list(
-		/datum/outfit/loadout/decvetbull,	// Supersledge, 10mm SMG, Smokebomb
+		/datum/outfit/loadout/decvetbull,	// Supersledge, Carl Gustaf, Smokebomb
 		/datum/outfit/loadout/decvetwolf,	// Thermic lance, Carl Gustaf, Extra Bitter
-		/datum/outfit/loadout/decvetsnake, // Brush gun, Ripper, Extra Bitters
-		/datum/outfit/loadout/decvetbrave, // trench shotgun, 44 revolver, ballistic fist
+		/datum/outfit/loadout/decvetsnake, // Brush Gun + Scope, Ripper, Extra Bitters
+		/datum/outfit/loadout/decvetbrave, // Lever-action Shotgun, 44 revolver, ballistic fist
 		)
 
 
@@ -370,7 +369,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 /datum/outfit/loadout/decvetbrave
 	name = "Mark of the Brave"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/decan
-	suit_store = /obj/item/gun/ballistic/shotgun/trench
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/ballisticfist = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
@@ -487,7 +486,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 
 	loadout_options = list(
 		/datum/outfit/loadout/recdeclegion,	// Uzi, Bumper sword, Smokebomb
-		/datum/outfit/loadout/recdectribal,	// M1 Garand, Throwing spears, Reinforced machete, Bottlecap mine
+		/datum/outfit/loadout/recdectribal,	// Unique Trail Carbine, Throwing spears, Reinforced machete, Bottlecap mine
 		)
 
 	matchmaking_allowed = list(
@@ -536,9 +535,9 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 
 /datum/outfit/loadout/recdectribal
 	name = "Blackliner Decanus"
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand
+	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail/tribal
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/garand3006 = 2,
+		/obj/item/ammo_box/m44box = 2,
 		/obj/item/melee/onehanded/machete/forgedmachete = 1,
 		/obj/item/storage/backpack/spearquiver = 1,
 		/obj/item/bottlecap_mine = 1,
@@ -651,8 +650,8 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	exp_requirements = 150
 
 	loadout_options = list(	// ALL: .45 Revolver, Machete
-		/datum/outfit/loadout/expambusher,	// lever-action shotgun, Bottlecap mine
-		/datum/outfit/loadout/expsniper,	// SKS, Smokebomb
+		/datum/outfit/loadout/expambusher,	// Lever-action Shotgun, Bottlecap mine
+		/datum/outfit/loadout/expsniper,	// Trail Carbine + Scope, Smokebomb
 		)
 
 	matchmaking_allowed = list(
@@ -707,9 +706,9 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 /datum/outfit/loadout/expsniper
 	name = "Sniper"
 	glasses = /obj/item/clothing/glasses/sunglasses/big
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand/sks
+	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/sks = 2,
+		/obj/item/ammo_box/m44box = 2,
 		/obj/item/grenade/smokebomb = 1,
 		/obj/item/gun_upgrade/scope/watchman = 1,
 		)
@@ -1045,7 +1044,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	flag = F13AUXILIA
 	total_positions = 3
 	spawn_positions = 3
-	description = "A non-combat position in the Legion for free citizens who perform tasks that need special training, such as surgery. They are loyal to the Legion even if they are not treated as equals to warriors."
+	description = "An auxiliary position in the Legion for free citizens who perform tasks that need special training, such as surgery. They are loyal to the Legion even if they are not treated as equals to warriors."
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_AUXILIA
 	outfit = /datum/outfit/job/CaesarsLegion/auxilia
@@ -1055,6 +1054,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/datum/outfit/loadout/auxassist, // Keep track of the money, handle trading beneath the warriors
 		/datum/outfit/loadout/auxmedicus, // Do surgery, medical tasks.
 		/datum/outfit/loadout/auxopifex, // Build defenses, craft necessary items
+		/datum/outfit/loadout/auxmilita, // Auxiliary infantry, drafted for combat.
 		)
 
 	matchmaking_allowed = list(
@@ -1101,9 +1101,9 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/folder/red = 1,
 		/obj/item/paper/natural = 2,
 		/obj/item/pen/fountain = 1,
-	//	/obj/item/storage/bag/money/small/legion = 1,
 		/obj/item/taperecorder = 1,
-		/obj/item/clothing/under/f13/legauxilia = 1,
+		/obj/item/clothing/under/f13/legauxilia = 1
+		/obj/item/stack/f13Cash/random/aureus/high = 2,
 		)
 
 /datum/outfit/loadout/auxmedicus
@@ -1137,6 +1137,17 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/weldingtool = 1,
 		/obj/item/book/granter/trait/explosives = 1
 		)
+
+/datum/outfit/loadout/auxmilita
+	name = "Auxiliary (Militia)"
+	belt = /obj/item/storage/belt/military/legion
+	suit = /obj/item/clothing/suit/armor/legion/recruit
+	shoes = /obj/item/clothing/shoes/f13/military/plated
+	backpack_contents = list(
+		/obj/item/restraints/legcuffs/bola = 1,
+		/obj/item/warpaint_bowl = 1,
+		/obj/item/twohanded/spear = 1,
+	)
 
 // LEGION SLAVES - Servant cook, and assist with medical, low surgery. Worker farm and mine.
 // Both get Mars teachings to help out when normal work is done.

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1040,6 +1040,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/stack/ore/blackpowder/twenty = 1,
 		/obj/item/book/granter/crafting_recipe/blueprint/r82 = 1,
 		/obj/item/clothing/head/beret/ncr/ncr_sapper = 1,
+		/obj/item/book/granter/trait/techno = 1,
 		)
 
 /datum/outfit/loadout/combatmedic

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -530,9 +530,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_requirements = 1750
 
 	loadout_options = list( // ALL: Binoculars, Bowie knife
-		/datum/outfit/loadout/vrclassic, // AMR, Sequoia
-		/datum/outfit/loadout/vrlite, // Brush, Sequoia
-		/datum/outfit/loadout/vrshotgunner, // Winchester City-Killer, Sequoia
+		/datum/outfit/loadout/vrclassic, // Sequoia
+		/datum/outfit/loadout/vrlite, // Brush
+		/datum/outfit/loadout/vrshotgunner, // Unique Lever-Action
 		/datum/outfit/loadout/vrcqc // 2 x .45 Long colt revolvers
 		)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1038,7 +1038,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle = 2,
 		/obj/item/stack/ore/blackpowder/twenty = 1,
-		/obj/item/book/granter/crafting_recipe/blueprint/r82 = 1
+		/obj/item/book/granter/crafting_recipe/blueprint/r82 = 1,
+		/obj/item/clothing/head/beret/ncr/ncr_sapper = 1,
 		)
 
 /datum/outfit/loadout/combatmedic
@@ -1051,7 +1052,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/clothing/gloves/color/latex/nitrile = 1,
 		/obj/item/clothing/head/f13/ncr/steelpot_med = 1,
 		/obj/item/book/granter/trait/midsurgery = 1,
-		/obj/item/book/granter/trait/chemistry = 1
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/clothing/head/beret/ncr/ncr_medic = 1,
 		)
 
 // TROOPER

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1713,7 +1713,7 @@
  * * * * * * * * * * */
 
 /obj/item/gun/ballistic/automatic/marksman/sniper/snipervenator
-	name = "Explorer sniper rifle"
+	name = "Centurion sniper rifle"
 	desc = "The customized sniper rifle, fitted with a telescopic sight for extreme accuracy and chambered for a high-ballistic performance centerfire cartridge. It is a superior version of the regular sniper rifle and is decorated with the flag of the bull and tokens of a hunt."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -157,6 +157,7 @@
 /obj/item/gun/ballistic/rifle/repeater/trail/tribal
 	name = "rainstick"
 	desc = "A sactified .44 lever action rifle, coated in detailed markings and a carved bead chain that sounds like rain."
+	icon = icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "trailcarbinet"
 	item_state = "trailcarbine"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -157,7 +157,7 @@
 /obj/item/gun/ballistic/rifle/repeater/trail/tribal
 	name = "rainstick"
 	desc = "A sactified .44 lever action rifle, coated in detailed markings and a carved bead chain that sounds like rain."
-	icon = icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "trailcarbinet"
 	item_state = "trailcarbine"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -476,7 +476,7 @@
 /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
 	name = "Mourning Sunrise"
 	desc = "A speedy lever action shotgun with a sunrise painted on the furnishings, morbid in context of it's purpose."
-	icon = icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "latribal"
 	item_state = "shotgunlever"
 	icon_prefix = "shotgunlever"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -476,6 +476,7 @@
 /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
 	name = "Mourning Sunrise"
 	desc = "A speedy lever action shotgun with a sunrise painted on the furnishings, morbid in context of it's purpose."
+	icon = icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "latribal"
 	item_state = "shotgunlever"
 	icon_prefix = "shotgunlever"


### PR DESCRIPTION
## About The Pull Request
Nerfs the Legion a little, though I think I already did before.
The only roles with a roundstart gun option is the Centurion, the Decanii, the Vexillari, Explorers and the Veteran Legionnaire.

Centurion:
Paladin Hunter - M1919 removed, replaced with the BAR. CQC removed.
Ranger Hunter - AMR removed, replaced with a unique DKS/Sniper Rifle.
Warlord - Given a unique lever-action shotgun.

Veteran Decanus:
Stupid shotgun loadout got replaced w/ a lever-action shotgun instead of a trench.

Prime Decanus left untouched.

Recruit Decanus:
Backlinder Loadout: M1 Garand replaced with a unique trail carbine.

Explorer:
SKS replaced with a trail carbine.

Auxilia:
Given an Auxiliary Militia role. Starts with recruit armour, tribal paint and a plain spear.

Rest of the Legion loadouts are fine / are all melee, shouldn't be an issue. Veteran Legionnaire has one gun loadout (a carl gustaf).

Added an Enclave remnant loadout to Town Citizen. Re-enabled Citizen loadouts.

Adds berets and a missing trait book to the NCR Corporal loadouts.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
