### PR TITLE
medical update - Wounds Made Easy (I want to fucking die.)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -147,6 +147,24 @@
 	time = 40
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/hydra
+	name = "Hydra"
+	result = /obj/item/reagent_containers/pill/patch/hydra
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/fungus = 3,
+				/obj/item/reagent_containers/food/snacks/grown/broc = 3)
+	time = 5
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/hydra5
+	name = "Hydra (x5)"
+	result = /obj/item/reagent_containers/pill/patch/hydra
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/fungus = 15,
+				/obj/item/reagent_containers/food/snacks/grown/broc = 15)
+	time = 15
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
 /*
 /datum/crafting_recipe/stimpak
 	name = "Stimpak"
@@ -236,6 +254,23 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/hemostatic
+	name = "Hemostatic applicator"
+	result = /obj/item/reagent_containers/hypospray/medipen/hemostatic
+	reqs = list(/obj/item/reagent_containers/syringe = 1,
+				/datum/reagent/medicine/hemostatic = 20)
+	time = 5
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/hemostatic5
+	name = "Hemostatic applicator (x5)"
+	result = /obj/item/reagent_containers/hypospray/medipen/hemostatic
+	reqs = list(/obj/item/reagent_containers/syringe = 5,
+				/datum/reagent/medicine/hemostatic = 100)
+	time = 5
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
 
 /datum/crafting_recipe/jet
 	name = "Jet"

--- a/code/game/objects/items/storage/f13storage.dm
+++ b/code/game/objects/items/storage/f13storage.dm
@@ -404,3 +404,22 @@
 /obj/item/storage/box/medicine/bitterdrink5/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/bitterdrink(src)
+
+// -----------------------------------
+// ANTI-WOUND BOXES
+
+/obj/item/storage/box/medicine/hemostatic5
+	name = "box of hemostatic applicators"
+	desc = "A box full of hemostatic applicators."
+
+/obj/item/storage/box/medicine/hemostatic5/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/hypospray/medipen/hemostatic(src)
+
+/obj/item/storage/box/medicine/hydra5
+	name = "box of hydra"
+	desc = "A box full of Hydra."
+
+/obj/item/storage/box/medicine/hydra5/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/patch/hydra(src)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -416,6 +416,6 @@ datum/chemical_reaction/rezadone
 	results = list(/datum/reagent/medicine/hemostatic = 20)
 	required_reagents = list(
 		/datum/reagent/medicine/bicaridine = 5,
-		/datum/chemical_reaction/morphine = 5,
+		/datum/reagent/medicine/morphine = 5,
 		/datum/reagent/medicine/styptic_powder = 10
 	)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -409,3 +409,13 @@ datum/chemical_reaction/rezadone
 		/datum/reagent/consumable/tea/bloodtea = 5
 		)
 	required_temp = 451
+
+/datum/chemical_reaction/hemostatic
+	name = "Hemostatic"
+	id = /datum/reagent/medicine/hemostatic
+	results = list(/datum/reagent/medicine/hemostatic = 20)
+	required_reagents = list(
+		/datum/reagent/medicine/bicaridine = 5,
+		/datum/chemical_reaction/morphine = 5,
+		/datum/reagent/medicine/styptic_powder = 10
+	)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -153,6 +153,13 @@
 	else
 		. += span_notice("It is spent.")
 
+/obj/item/reagent_containers/hypospray/medipen/hemostatic
+	name = "hemostatic applicator"
+	desc = "A fast-acting chemical hemotatic. Used to quickly clot and close bleeding wounds."
+	amount_per_transfer_from_this = 20
+	volume = 20
+	list_reagents = list(/datum/reagent/medicine/hemostatic = 20)
+
 ///////////////////
 // FALLOUT HYPOS //
 ///////////////////

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -139,13 +139,13 @@
 	. = ..()
 
 // ---------------------------------
-// HYDRA - never a thing, make it something. Sprites done.
+// HYDRA - now a thing. KYS furries.
 
-/* /obj/item/reagent_containers/pill/patch/hydra
+ /obj/item/reagent_containers/pill/patch/hydra
 	name = "Hydra"
-	desc = "Hydra is a drug developed from antivenom. Due to the Legion's disapproval of using modern medicine, some Legionaries attempted to develop a different means to help them heal damaged limbs. To do that, they combined cave fungus, nightstalker blood and the poison from a radscorpion poison gland with antivenom before use. This resulted in the development of Hydra, a curative agent that both anesthetizes and restores crippled limbs over time."
+	desc = "A potent blend of herbs and plants used by Tribals and Legionnaires alike to quickly close wounds."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_hydra"
-	list_reagents = null
+	list_reagents = list(/datum/reagent/medicine/hydra = 20)
 	self_delay = 0
- */
+ 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -148,4 +148,3 @@
 	icon_state = "patch_hydra"
 	list_reagents = list(/datum/reagent/medicine/hydra = 20)
 	self_delay = 0
- 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -148,3 +148,4 @@
 	icon_state = "patch_hydra"
 	list_reagents = list(/datum/reagent/medicine/hydra = 20)
 	self_delay = 0
+

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -148,4 +148,3 @@
 	icon_state = "patch_hydra"
 	list_reagents = list(/datum/reagent/medicine/hydra = 20)
 	self_delay = 0
-

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -141,7 +141,7 @@
 // ---------------------------------
 // HYDRA - now a thing. KYS furries.
 
- /obj/item/reagent_containers/pill/patch/hydra
+/obj/item/reagent_containers/pill/patch/hydra
 	name = "Hydra"
 	desc = "A potent blend of herbs and plants used by Tribals and Legionnaires alike to quickly close wounds."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'

--- a/fallout/reagents/medicines.dm
+++ b/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	reagent_state = LIQUID
 	color = "#eb0000"
 	taste_description = "numbness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 	overdose_threshold = 60
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE

--- a/fallout/reagents/medicines.dm
+++ b/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	reagent_state = LIQUID
 	color = "#eb0000"
 	taste_description = "numbness"
-	metabolization_rate = 0.8 * REAGENTS_METABOLISM
+	metabolization_rate = 3 * REAGENTS_METABOLISM
 	overdose_threshold = 60
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
@@ -102,7 +102,7 @@
 	reagent_state = LIQUID
 	color = "#e50d0d"
 	taste_description = "numbness"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	overdose_threshold = 40	// you can risk a second dose
 	ghoulfriendly = TRUE
 	var/damage_offset = 6.75	//How much damage will be offset in one tick
@@ -702,7 +702,7 @@
 	description = "Hemostatic granules that help to stop bleeding."
 	reagent_state = LIQUID
 	color = "#bb2424"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	overdose_threshold = 25
 	bleed_mult = 0.025
 	// How much base clotting we do per bleeding wound, multiplied by the below number for each bleeding wound
@@ -740,7 +740,7 @@
 	description = "A potent mix of herbs that help to stem bleeding."
 	reagent_state = LIQUID
 	color = "#bb2424"
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
 	overdose_threshold = 25
 	bleed_mult = 0.025
 	var/clot_rate = 3


### PR DESCRIPTION
## About The Pull Request
Introduces two new clotting agents - a chemical hemostatic and Hydra.

Hemostatic is made with 1 parts Morphine and Bicaridine to two parts styptic powder.
Hydra is made with three cave fungus and three broc flowers.
You can make them in the medical crafting menu. Hemostatic has to be chemically synthesised first, and then made w/ syringes to make injectors.

Both of these are powerful coagulants that stem the flow of bleeding. However, it does not *close the wounds themselves*, and they are meant to be used in conjunction with sutures or bandages. Here is an example of how to use them:
- You are hit with a bullet in the chest.
- You receive a puncture wound.
- You are losing 4u of blood per tick.
- You apply a hemostatic applicator/a hydra patch.
- This reduces the rate at which you lose blood to 0.1-ish per tick.
- This also makes it easier for sutures/bandages to close your wound (I think?).
- You can then apply a suture/bandage to fully close the wound.

This also actually makes stims metabolise.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Hemostatic injectors/hydra.
fix: Stimfluid not metabolising.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
