### PR TITLE
Fixes Detective Loadout

### DIFF
--- a/code/modules/jobs/job_types/eastwood.dm
+++ b/code/modules/jobs/job_types/eastwood.dm
@@ -1164,7 +1164,7 @@ Mayor
 	r_pocket = /obj/item/flashlight/flare
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
-	suit_store = /obj/item/gun/ballistic/revolver
+	suit_store = /obj/item/gun/ballistic/revolver/colt357
 	backpack_contents = list(
 		/obj/item/storage/pill_bottle/chem_tin/radx,
 		/obj/item/pda/detective=1,


### PR DESCRIPTION
Currently the detective spawns in with a 'revolver template' in .357. This replaces it with a common .357 revolver. Yippie.