### PR TITLE
Removes slime extracts from cargo

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -317,7 +317,7 @@
 					/obj/item/grenade/clusterbuster/syndieminibomb,
 					/obj/item/grenade/clusterbuster/teargas,
 					/obj/item/grenade/clusterbuster/clf3,
-					/obj/item/grenade/clusterbuster/slime,
+				//	/obj/item/grenade/clusterbuster/slime, No. ~Pokee
 					/obj/item/grenade/clusterbuster/facid)
 	crate_name = "clusterbang grenade pack crate"
 
@@ -327,7 +327,7 @@
 	cost = 1500
 	contains = list(/obj/item/storage/box/stingbangs)
 	crate_name = "stingbang grenade pack crate"
-
+/*
 /datum/supply_pack/security/crossbreeddangerous
 	name = "Dangerous Crossbreeds Pack"
 	desc = "Contains five of a various selection of slime cross breed items that are dangerous to use."
@@ -431,7 +431,7 @@
 					/obj/item/slimecross/recurring/pyrite,
 					/obj/item/slimecross/recurring/pink)
 	crate_name = "utility crossbreed crate"
-
+*/
 /datum/supply_pack/security/traitbooks
 	name = "Technical manuals"
 	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."

--- a/fallout/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/fallout/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -126,7 +126,7 @@
 	FermiExplode 		= TRUE		// If the chemical explodes in a special way
 	PurityMin 			= 0.2
 
-/datum/chemical_reaction/fermi/SDGF/FermiExplode(datum/reagents, atom/my_atom, volume, temp, pH)//Spawns an angery teratoma!
+/*/datum/chemical_reaction/fermi/SDGF/FermiExplode(datum/reagents, atom/my_atom, volume, temp, pH)//Spawns an angery teratoma!
 	var/turf/T = get_turf(my_atom)
 	var/amount_to_spawn = round((volume/100), 1)
 	if(amount_to_spawn <= 0)
@@ -139,7 +139,7 @@
 		S.rabid = 1//Make them an angery boi
 		S.color = "#810010"
 	my_atom.reagents.clear_reagents()
-	my_atom.visible_message(span_warning("An horrifying tumoural mass forms in [my_atom]!"))
+	my_atom.visible_message(span_warning("An horrifying tumoural mass forms in [my_atom]!"))*/
 
 /datum/chemical_reaction/fermi/astral
 	name = "Astrogen"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
As the title says, removes the slime crossbreed crates and the chance for the slime grenade to spawn in cargo to stop people from doing OP shit like making slime speed potions, consciousness transference potions, etc.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Removed slimes from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
