### PR TITLE
Thick Skin Balance

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -69,6 +69,11 @@
 
 	var/mob/living/carbon/human/H = arrived
 	if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
+		(H.Paralyze(60))
+			(H.visible_message(
+				span_danger("[H] trips into [parent] unharmed."),
+				span_userdanger("You trip into [parent], but your thick skin saves you from damage!"))
+			)
 		return
 
 	if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
@@ -104,8 +109,8 @@
 	if(!(flags & CALTROP_SILENT) && !H.has_status_effect(/datum/status_effect/caltropped))
 		H.apply_status_effect(/datum/status_effect/caltropped)
 		H.visible_message(
-			span_danger("[H] steps on [parent]."),
-			span_userdanger("You step on [parent]!")
+			span_danger("[H] steps on [parent] like a dipshit."),
+			span_userdanger("You step on [parent] like a moron!")
 		)
 
 	INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, apply_damage), damage, BRUTE, picked_def_zone, FALSE, FALSE, FALSE, CANT_WOUND)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -926,7 +926,7 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 
 /datum/quirk/thickskin
 	name = "Thick Skin"
-	desc = "You just don't get splinters, or shrapnel for that matter.  BROKEN AS OF 2/9/23, TAKE LICK HEALING TO CLOSE WOUNDS."
+	desc = "You just don't get splinters, or shrapnel for that matter. Barbed wire will still be a struggle, even if it doesn't hurt."
 	value = 3
 	mob_trait = TRAIT_PIERCEIMMUNE
 	gain_text = span_notice("Your skin feels way stronger.")


### PR DESCRIPTION
## About The Pull Request
Changes it so if you have the "Thick Skin" quirk, you still receive a knockdown but no damage. Also changes the messages for stepping on barbed wire for the sake of humor.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Changed how Thick Skin interacts w/ caltrops-based traps.
/:cl: