### PR TITLE
Adds an auto balancing system for the NCR and Legion (TM ONLY)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -763,6 +763,15 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 			living_player_count += 1
 	return living_player_count
 
+/proc/living_faction_player_count(faction = "faction")
+	var/living_faction_player_count = 0
+	for(var/mob in GLOB.player_list)
+		if(mob in GLOB.alive_mob_list)
+			var/mob/dude = mob
+			if(faction in dude.faction)
+				living_faction_player_count += 1
+	return living_faction_player_count
+
 /proc/randomColor(mode = 0)	//if 1 it doesn't pick white, black or gray
 	switch(mode)
 		if(0)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -337,6 +337,8 @@
 
 /datum/config_entry/number/border_control // If border control is enabled
 
+/datum/config_entry/number/auto_balancing //If auto balancing factions is enabled
+
 /datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker
 
 /// Flag for requiring players who would otherwise be denied access by the panic bunker to complete a written interview

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -91,7 +91,8 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/datum/admins/proc/open_borgopanel,
 	/datum/admins/proc/toggle_sleep,
 	/datum/admins/proc/toggle_sleep_area,
-	/datum/admins/proc/toggle_faction_join
+	/datum/admins/proc/toggle_faction_join,
+	/datum/admins/proc/AB_ToggleState
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/DB_ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)

--- a/code/modules/auto_balancing/auto_balance.dm
+++ b/code/modules/auto_balancing/auto_balance.dm
@@ -1,0 +1,33 @@
+#define AUTO_BALANCING_DISABLED 0
+#define AUTO_BALANCING_ENABLED 1
+
+proc/AB_ModeToText(var/mode)
+	switch(mode)
+		if(AUTO_BALANCING_DISABLED)
+			return "Disabled"
+		if(AUTO_BALANCING_ENABLED)
+			return "Enabled"
+
+/datum/admins/proc/AB_ToggleState()
+
+	set name = "Auto Balancing - Toggle Mode"
+	set category = "Admin.Game"
+	set desc="Enables or disables faction auto balancing"
+
+	var/AutoBalanceMode = CONFIG_GET(number/auto_balancing)
+
+	var/choice = input("New State (Current state is: [AB_ModeToText(AutoBalanceMode)])", "Faction Auto Balancing State") as null|anything in list("Disabled", "Enabled")
+
+	switch(choice)
+		if("Disabled")
+			if(AutoBalanceMode != AUTO_BALANCING_DISABLED)
+				AutoBalanceMode = AUTO_BALANCING_DISABLED
+				log_and_message_admins("has disabled faction auto balancing.")
+		if("Enabled")
+			if(AutoBalanceMode != AUTO_BALANCING_ENABLED)
+				AutoBalanceMode = AUTO_BALANCING_ENABLED
+				log_and_message_admins("has enabled faction auto balancing.")
+
+	CONFIG_SET(number/auto_balancing, AutoBalanceMode)
+
+	return

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -289,3 +289,17 @@ GLOBAL_PROTECT(exp_to_update)
 		prefs.db_flags = 0	//This PROBABLY won't happen, but better safe than sorry.
 	qdel(flags_read)
 	return TRUE
+
+/datum/job/proc/auto_balance(title)
+	var/AutoBalanceMode = CONFIG_GET(number/auto_balancing)
+	var/bear = living_faction_player_count(FACTION_NCR)
+	var/bull = living_faction_player_count(FACTION_LEGION)
+	if(AutoBalanceMode == AUTO_BALANCING_DISABLED)
+		return TRUE	
+	if(world.time <= 30 MINUTES)
+		return TRUE
+	if(title in GLOB.ncr_positions && bear >= bull*2)
+		return FALSE
+	if(title in GLOB.legion_positions && bull >= bear*2)
+		return FALSE	
+	return TRUE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -436,6 +436,8 @@
 		return JOB_UNAVAILABLE_WHITELIST
 	if(latejoin && !job.special_check_latejoin(client))
 		return JOB_UNAVAILABLE_GENERIC
+	if(latejoin && !job.auto_balance(job.title))
+		return JOB_UNAVAILABLE_GENERIC
 	if(!client.prefs.pref_species.qualifies_for_rank(rank, client.prefs.features))
 		return JOB_UNAVAILABLE_SPECIESLOCK
 	if(LAZYLEN(SSmapping?.config?.removed_jobs))

--- a/config/config.txt
+++ b/config/config.txt
@@ -557,3 +557,7 @@ BORDER_CONTROL 1
 # DISCORDIMAGE_P https://media.discordapp.net/attachments/
 # DISCORDIMAGE_S .png
 
+## Whether or not faction auto balancing will be used
+## 0 Disables auto balancing
+## 1 Enables auto balancing
+AUTO_BALANCING 1

--- a/hailmary.dme
+++ b/hailmary.dme
@@ -1877,6 +1877,7 @@
 #include "code\modules\atmospherics\machinery\portable\portable_atmospherics.dm"
 #include "code\modules\atmospherics\machinery\portable\pump.dm"
 #include "code\modules\atmospherics\machinery\portable\scrubber.dm"
+#include "code\modules\auto_balancing\auto_balance.dm"
 #include "code\modules\awaymissions\away_props.dm"
 #include "code\modules\awaymissions\bluespaceartillery.dm"
 #include "code\modules\awaymissions\capture_the_flag.dm"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
After grace ends, the system will check if NCR/Legion has double the players of the other faction, if they do it disables the spawns for the NCR/Legion until they get more players. It has both a config toggle and an admin button toggle.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: added a faction auto balancing system
config: added config lines for enabling/disabling the auto balancing by default
admin: gave admins a button to toggle off/on the auto balancing (good for events)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
