### PR TITLE
Unfuck-stim-Hemo

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -415,7 +415,7 @@ datum/chemical_reaction/rezadone
 	id = /datum/reagent/medicine/hemostatic
 	results = list(/datum/reagent/medicine/hemostatic = 20)
 	required_reagents = list(
-		/datum/reagent/medicine/brocjuice = 5,
-		/datum/reagent/medicine/xanderjuice = 5,
+		/datum/reagent/consumable/brocjuice = 5,
+		/datum/reagent/consumable/xanderjuice = 5,
 		/datum/reagent/medicine/styptic_powder = 10
 	)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -387,7 +387,7 @@ datum/chemical_reaction/rezadone
 /datum/chemical_reaction/stimfluid
 	name = "stimfluid"
 	id = /datum/reagent/medicine/stimpak
-	results = list(/datum/reagent/medicine/stimpak = 5)
+	results = list(/datum/reagent/medicine/stimpak = 25)
 	required_reagents = list(
 		/datum/reagent/medicine/bicaridine = 5,
 		/datum/reagent/medicine/kelotane = 5,
@@ -415,7 +415,7 @@ datum/chemical_reaction/rezadone
 	id = /datum/reagent/medicine/hemostatic
 	results = list(/datum/reagent/medicine/hemostatic = 20)
 	required_reagents = list(
-		/datum/reagent/medicine/bicaridine = 5,
-		/datum/reagent/medicine/morphine = 5,
+		/datum/reagent/medicine/brocjuice = 5,
+		/datum/reagent/medicine/xanderjuice = 5,
 		/datum/reagent/medicine/styptic_powder = 10
 	)

--- a/fallout/reagents/medicines.dm
+++ b/fallout/reagents/medicines.dm
@@ -39,7 +39,7 @@
 	var/is_blocked = FALSE
 	if(!is_blocked)
 		//Clotting properties for pierce/slash wounds
-		if(current_cycle > 0 && current_cycle % 6 == 0 && M.all_wounds && M.all_wounds.len >= 1)	//Every 6th cycle, reduce blood_flow for all pierce/slash wounds by clot_rate.
+		if(current_cycle > 0 && current_cycle % 6 == 0 && M.all_wounds && M.all_wounds.len >= 2)	//Every 6th cycle, reduce blood_flow for all pierce/slash wounds by clot_rate.
 			for(var/datum/wound/iter_wound in M.all_wounds)
 				var/affected_limb_name = iter_wound.limb.name
 				switch(iter_wound.severity)
@@ -107,6 +107,47 @@
 	ghoulfriendly = TRUE
 	var/damage_offset = 6.75	//How much damage will be offset in one tick
 	var/clot_rate = 0.65	
+
+/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M)
+
+	. = ..()
+	var/is_blocked = FALSE
+	if(!is_blocked)
+		//Clotting properties for pierce/slash wounds
+		if(current_cycle > 0 && current_cycle % 6 == 0 && M.all_wounds && M.all_wounds.len >= 1)	//Every 6th cycle, reduce blood_flow for all pierce/slash wounds by clot_rate.
+			for(var/datum/wound/iter_wound in M.all_wounds)
+				var/affected_limb_name = iter_wound.limb.name
+				switch(iter_wound.severity)
+					if (WOUND_SEVERITY_CRITICAL)
+						if (iter_wound.wound_type == WOUND_PIERCE)
+							iter_wound.blood_flow -= clot_rate
+							M.visible_message("<span class='notice'>The bleeding hole in [M]'s [affected_limb_name] fills with fresh tissue!</span>", \
+											  "<span class='notice'>You feel the cavity in your [affected_limb_name] weaving back together.</span>")
+						else if (iter_wound.wound_type == WOUND_SLASH)
+							iter_wound.blood_flow -= clot_rate
+							M.visible_message("<span class='notice'>The deep gashes on [M]'s [affected_limb_name] close up!</span>", \
+											  "<span class='notice'>You feel the deep gashes on your [affected_limb_name] close up.</span>")
+					if (WOUND_SEVERITY_SEVERE)
+						if (iter_wound.wound_type == WOUND_PIERCE)
+							iter_wound.blood_flow -= clot_rate
+							M.visible_message("<span class='notice'>The puncture wound on [M]'s [affected_limb_name] shrinks!</span>", \
+											  "<span class='notice'>You feel the puncture wound on your [affected_limb_name] shrinking.</span>")
+						else if (iter_wound.wound_type == WOUND_SLASH)
+							iter_wound.blood_flow -= clot_rate
+							M.visible_message("<span class='notice'>The large cuts on [M]'s [affected_limb_name] mend!</span>", \
+											  "<span class='notice'>You feel the large cuts on your [affected_limb_name] mending.</span>")
+					if (WOUND_SEVERITY_MODERATE)
+						if (iter_wound.wound_type == WOUND_PIERCE || iter_wound.wound_type == WOUND_SLASH)
+							iter_wound.blood_flow -= clot_rate
+
+		//Actual healing part starts here
+		M.adjustBruteLoss(-damage_offset * 1.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.adjustFireLoss(-damage_offset * 1.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.AdjustStun(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.AdjustKnockdown(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.adjustStaminaLoss(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.heal_bodypart_damage(damage_offset, damage_offset * 3, only_robotic = TRUE, only_organic = FALSE)	
+		. = TRUE
 
 // ---------------------------
 // LONGPORK STEW REAGENT

--- a/fallout/reagents/medicines.dm
+++ b/fallout/reagents/medicines.dm
@@ -141,8 +141,8 @@
 							iter_wound.blood_flow -= clot_rate
 
 		//Actual healing part starts here
-		M.adjustBruteLoss(-damage_offset * 1.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
-		M.adjustFireLoss(-damage_offset * 1.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.adjustBruteLoss(-damage_offset * 1.7 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
+		M.adjustFireLoss(-damage_offset * 1.7 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
 		M.AdjustStun(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
 		M.AdjustKnockdown(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	
 		M.adjustStaminaLoss(-damage_offset * 0.90 * REAGENTS_EFFECT_MULTIPLIER, FALSE)	


### PR DESCRIPTION
## About The Pull Request
This PR aims to unfuck the stimfluid recipe and the hemostatic recipe by changing the bicard, morphine to brocjuice and xanderjuice. Prior to this PR hemostatic used three of the five reagents in stimfluid causing people to make hemostatic instead of the much preferred stimfluid.

Stimfluid, Im unsure why 25 units made 5 units of stimfluid, but even poke said stimpacks where near impossible to make, since who would want to make all those things just to get 5 units of shit for their work? Well I am aiming to change that 5 units to 25u, to make stimpacks available to be made again with out the person wanting to kill them self through the process

EDIT: Fixed super stim packs not healing by yoinking the Stimpak healing and adding a .7 to brute and burn, 
From testing stimpacks heal around 7 brute per tick where the supers heal 12-13 per tick

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked stimfluid and hemostatic recipes
balance: balanced the shit stimfluid recipe by giving you what you put in
fix: fixed trying to make stimfluid only to be rewarded with hemostatic. Fixed
fix: Fixed super stims not healing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
