### PR TITLE
Removes more ways for slimes and morphs to be spawned

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -943,7 +943,7 @@
 	randomize_human(H)
 
 
-/datum/reagent/aslimetoxin
+/*/datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
 	description = "An advanced corruptive toxin produced by slimes."
 	color = "#13BC5E" // rgb: 19, 188, 94
@@ -965,7 +965,7 @@
 	ghoulfriendly = TRUE
 
 /datum/reagent/gluttonytoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	L.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
+	L.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)*/
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -425,13 +425,13 @@
 
 //Black
 
-/datum/chemical_reaction/slime/slimemutate2
+/*/datum/chemical_reaction/slime/slimemutate2
 	name = "Advanced Mutation Toxin"
 	id = /datum/reagent/aslimetoxin
 	results = list(/datum/reagent/aslimetoxin = 1)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
-	required_container = /obj/item/slime_extract/black
+	required_container = /obj/item/slime_extract/black*/
 
 
 //Oil

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -252,12 +252,12 @@
 	volume = 1
 	list_reagents = list(/datum/reagent/mulligan = 1)
 
-/obj/item/reagent_containers/syringe/gluttony
+/*/obj/item/reagent_containers/syringe/gluttony
 	name = "Gluttony's Blessing"
 	desc = "A syringe recovered from a dread place. It probably isn't wise to use."
 	amount_per_transfer_from_this = 1
 	volume = 1
-	list_reagents = list(/datum/reagent/gluttonytoxin = 1)
+	list_reagents = list(/datum/reagent/gluttonytoxin = 1)*/
 
 /obj/item/reagent_containers/syringe/bluespace
 	name = "bluespace syringe"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Comments out two reagents I missed when doing my first mutation toxin removal.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: removed advanced mutation toxin and gluttony's blessing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
