### PR TITLE
Fixes disconnected player timers not showing

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -418,9 +418,9 @@
 				msg += span_deadsay("[t_He] [t_is] totally catatonic. The stresses of the Wasteland must have been too much for [t_him]. Any recovery is unlikely.")
 			else if(!client)
 				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
-			else if(client && ((client.inactivity / 10) / 60 > 10)) //10 Minutes
+			if(client && ((client.inactivity / 10) / 60 > 10)) //10 Minutes
 				msg += "\[Inactive for [round((client.inactivity/10)/60)] minutes\]"
-			else if(disconnect_time)
+			if(disconnect_time)
 				msg += "\[Disconnected/ghosted [round(((world.realtime - disconnect_time)/10)/60)] minutes ago\]"
 
 		if(digitalcamo)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Hopefully it will once again show how long a player has been disconnected for when examining them, which should make it easier for players to tell if someone likely isn't coming back and can be matrixed or not.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed the message for disconnected clients not showing the time they've been DC'd for when examining them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
