### PR TITLE
Removes the EMP ability from proton axes

### DIFF
--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -530,7 +530,7 @@
 	else if(istype(A, /turf/closed))
 		playsound(loc, hitsound, 70, TRUE)
 
-// Proton axe			Keywords: Damage 28/55 fire axe but with a twist, if this works. I've either given it a cool gimmick, or broken everything
+// Proton axe			Keywords: Damage 28/55 fire axe but blue
 /obj/item/melee/transforming/energy/axe/protonaxe
 	name = "proton axe"
 	desc = "The experimental proton axe resembles a futuristic war-axe with a glowing blue blade of electrical energy at its head."
@@ -550,13 +550,11 @@
 	attack_speed = CLICK_CD_MELEE * 1.25
 	var/emp_radius = 1
 
-/obj/item/melee/transforming/energy/axe/protonaxe/afterattack(atom/A, mob/living/user, proximity)
+/*/obj/item/melee/transforming/energy/axe/protonaxe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
 	if(!active)
 		return
-	empulse_using_range(A, emp_radius, log=0) //fox go a (A)
-
-//dan kelly is a nerd NO YOU ARE!!!
+	empulse_using_range(A, emp_radius, log=0)*/ //Commented out due to admin log spam -Pokee
 
 // Super Sledge			Keywords: Damage 25/60
 /obj/item/twohanded/sledgehammer/supersledge


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Does as the title says and removes the localized EMP on proton axe hits. This was done due to it spamming admin logs **every single time the proton axe hits something**. 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: removed the proton axe's EMP ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
