### PR TITLE
Lets stronger mobs kill people

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -131,6 +131,7 @@
 	mob_armor = ARMOR_VALUE_ROBOT_SECURITY
 	maxHealth = 150 
 	health = 150
+	stat_attack = UNCONSCIOUS
 	del_on_death = FALSE
 	melee_damage_lower = 24
 	melee_damage_upper = 55

--- a/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/centaur.dm
@@ -71,6 +71,7 @@
 /mob/living/simple_animal/hostile/centaur/strong // Mostly for FEV mutation
 	maxHealth = 400
 	health = 400
+	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 35
 	melee_damage_upper = 35
 	armour_penetration = 0.1
@@ -89,6 +90,7 @@
 
 	maxHealth = 1000
 	health = 1000
+	stat_attack = UNCONSCIOUS
 	speed = -0.5
 	harm_intent_damage = 8
 	melee_damage_lower = 30
@@ -157,6 +159,7 @@
 	speed = -0.5
 	maxHealth = 700
 	health = 700
+	stat_attack = UNCONSCIOUS
 	harm_intent_damage = 8
 	melee_damage_lower = 30
 	melee_damage_upper = 40

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -15,6 +15,7 @@
 	sentience_type = SENTIENCE_BOSS
 	maxHealth = 600
 	health = 600
+	stat_attack = UNCONSCIOUS
 	reach = 2
 	speed = 1
 	obj_damage = 200

--- a/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/fallout_NPC.dm
@@ -214,6 +214,7 @@
 	icon_living = "enclave_armored"
 	maxHealth = 560
 	health = 650
+	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 20
 	melee_damage_upper = 47
 	extra_projectiles = 2
@@ -344,6 +345,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/bs/paladin)
 	maxHealth = 480
 	health = 480
+	stat_attack = UNCONSCIOUS
 	healable = 1
 	ranged = 1
 	projectiletype = /obj/item/projectile/beam/laser/lasgun/hitscan

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -248,6 +248,7 @@
 	can_ghost_into = FALSE
 	maxHealth = 200
 	health = 200
+	stat_attack = UNCONSCIOUS
 	speed = 2.5
 	harm_intent_damage = 8
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
@@ -151,6 +151,7 @@
 	speed = 5
 	maxHealth = 560
 	health = 560
+	stat_attack = UNCONSCIOUS
 	ranged = 1
 	harm_intent_damage = 8
 	obj_damage = 20

--- a/code/modules/mob/living/simple_animal/hostile/f13/mirelurks.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/mirelurks.dm
@@ -69,6 +69,7 @@
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/mirelurk = 4, /obj/item/stack/sheet/sinew = 2)
 	maxHealth = 160
 	health = 160
+	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 15
 	melee_damage_upper = 28
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -148,6 +148,7 @@
 	mob_armor = ARMOR_VALUE_RAIDER_LEATHER_JACKET
 	maxHealth = 300
 	health = 300
+	stat_attack = UNCONSCIOUS
 	speed = 1.2
 	obj_damage = 300
 	rapid_melee = 1
@@ -165,6 +166,7 @@
 	mob_armor = ARMOR_VALUE_RAIDER_LEATHER_JACKET
 	maxHealth = 240
 	health = 240
+	stat_attack = UNCONSCIOUS
 	retreat_distance = 1
 	minimum_distance = 2
 	rapid_melee = 1
@@ -200,6 +202,7 @@
 	mob_armor = ARMOR_VALUE_RAIDER_COMBAT_ARMOR_BOSS
 	maxHealth = 150
 	health = 150
+	stat_attack = UNCONSCIOUS
 	extra_projectiles = 2
 	rapid_melee = 1
 	waddle_amount = 4
@@ -590,6 +593,7 @@
 	mob_armor = ARMOR_VALUE_RAIDER_COMBAT_ARMOR_BOSS
 	maxHealth = 165
 	health = 165
+	stat_attack = UNCONSCIOUS
 	ranged = TRUE
 	rapid_melee = 1
 	retreat_distance = 4

--- a/code/modules/mob/living/simple_animal/hostile/f13/rattler.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/rattler.dm
@@ -16,6 +16,7 @@ using ant armor b/c it just kinda works here and i don't want it to be super bee
 	mob_armor = ARMOR_VALUE_ANTS
 	maxHealth = 150
 	health = 150
+	stat_attack = UNCONSCIOUS
 	reach = 2
 	speed = -1
 	move_to_delay = 2.1

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -13,6 +13,7 @@
 	sentience_type = SENTIENCE_BOSS
 	maxHealth = 130 
 	health = 130
+	stat_attack = UNCONSCIOUS
 	speak_chance = 10
 	speak = list(
 		"GRRRRRR!",

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -115,6 +115,7 @@
 	mob_armor = ARMOR_VALUE_ROBOT_MILITARY
 	maxHealth = 100 
 	health = 100
+	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 18
 	melee_damage_upper = 64
 	attack_sound = 'sound/items/welder.ogg'
@@ -254,6 +255,7 @@
 	mob_armor = ARMOR_VALUE_ROBOT_SECURITY
 	maxHealth = 110 
 	health = 110
+	stat_attack = UNCONSCIOUS
 	can_ghost_into = FALSE
 	melee_damage_lower = 15
 	melee_damage_upper = 37
@@ -310,6 +312,7 @@
 	mob_armor = ARMOR_VALUE_ROBOT_CIVILIAN
 	maxHealth = 100 
 	health = 100
+	stat_attack = UNCONSCIOUS
 	speed = 4
 	can_ghost_into = TRUE
 	melee_damage_lower = 5 //severely reduced melee damage here because its silly to have a ranged mob also be a cqc master
@@ -488,6 +491,7 @@
 	mob_armor = ARMOR_VALUE_ROBOT_MILITARY
 	maxHealth = 100 
 	health = 100
+	stat_attack = UNCONSCIOUS
 	can_ghost_into = FALSE
 	mob_biotypes = MOB_ROBOTIC|MOB_INORGANIC
 	speed = 1


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Previously if you were attacked by a deathclaw or any other mob they would only attack you until you went to critical condition. Now most mobs that are on the stronger side will fully kill you, making mobs way more threatening to fight.

A full list of every mob that will fully kill you:

- Sentrybots
- Securitrons
- FEV Created Centaurs (The strong ones)
- Abominations
- All deathclaw types
- Enclave AI NPCs
- Brotherhood Paladin NPCs
- Legendary Ghouls
- Ant Queens
- Mirelurk Hunters
- Legendary Raiders, Raider Bosses, and Junker Bosses
- Rattlers (An unused mob, but they were strong enough that I gave it to them just incase)
- Super Mutants
- Gutsys, Robobrains, Protectrons, and Assaultrons

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: rebalanced when most mobs will stop attacking you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
