### PR TITLE
Readds back flavortext minimum Requirement.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -41,7 +41,7 @@
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			4096		//Citadel edit: What's the WORST that could happen?
 #define MAX_FLAVOR_LEN			4096
-#define MIN_FLAVOR_LEN			100
+#define MIN_FLAVOR_LEN			75
 #define MIN_OOC_LEN				20 // Will not allow just smileys to be on OOC notes.
 #define MAX_TASTE_LEN			40
 #define MAX_NAME_LEN			42

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -178,6 +178,9 @@
 		//This is likely not an actual issue but I don't have time to prove that this
 		//no longer is required
 		if(SSticker.current_state <= GAME_STATE_PREGAME)
+			if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+				to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
+				return
 			ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
 		if(SSticker.current_state >= GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
@@ -195,6 +198,10 @@
 	if(href_list["late_join"])
 		if(!SSticker || !SSticker.IsRoundInProgress())
 			to_chat(usr, span_danger("The round is either not ready, or has already finished..."))
+			return
+		
+		if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+			to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
 			return
 
 		if(href_list["late_join"] == "override")
@@ -461,6 +468,10 @@
 
 	if(SSticker.late_join_disabled)
 		alert(src, "An administrator has disabled late join spawning.")
+		return FALSE
+
+	if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+		to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
 		return FALSE
 
 	var/arrivals_docked = TRUE


### PR DESCRIPTION
## About The Pull Request

This adds back the Minimum 75 characters required for in flavor text.
Shorter than previous servers, where the minimum was 100.
Might also help people to invest themself a bit more in IC maters.  