### PR TITLE
Update legion.dm - give Treasurer caps (500)

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1117,7 +1117,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/pen/fountain = 1,
 		/obj/item/taperecorder = 1,
 		/obj/item/clothing/under/f13/legauxilia = 1,
-		/obj/item/stack/f13Cash/random/aureus/high = 2,
+		/obj/item/stack/f13Cash/caps/fivezerozero = 1,
 		)
 
 /datum/outfit/loadout/auxmedicus


### PR DESCRIPTION
## About The Pull Request
Someone set the stack spawn numbers to zero for every currency that isn't caps, so giving Treasurer caps is easier than fixing that problem in f13Cash.dm

## Pre-Merge Checklist
- [no ] You tested this on a local server.
- [idk ] This code did not runtime during testing.
- [yeah ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Replaced the Aureus that Treasurer spawns with with 500 caps flat (not a chance based amount)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
