### PR TITLE
Removing Tower Shield - only Scrap Ones Now

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -406,27 +406,6 @@ obj/item/shield/riot/bullet_proof
 		to_chat(user, span_notice("[src] can now be concealed."))
 	add_fingerprint(user)
 
-/obj/item/shield/riot/tower
-	name = "tower shield"
-	desc = "A heavy metal tower shield. Very unwieldly."
-	icon_state = "shield_tower"
-	item_state = "shield_tower"
-	slot_flags = ITEM_SLOT_BACK
-	shieldbash_cooldown = 8 SECONDS
-	shieldbash_brutedamage = 50//if you close in with this, and land a shieldbash you should deal a good bit of damage
-	shieldbash_stamdmg = 80//and stamina
-	force = 25
-	block_parry_data = /datum/block_parry_data/shield/tower
-	throwforce = 5
-	throw_speed = 1
-	throw_range = 1
-	slowdown = 0.2
-	w_class = WEIGHT_CLASS_HUGE
-	custom_materials = list(/datum/material/iron = 32000)
-	repair_material = /obj/item/stack/sheet/metal
-	shield_flags = SHIELD_FLAGS_HEAVY
-	max_integrity = -1
-
 /datum/block_parry_data/shield/tower
 	block_slowdown = 0.75
 	block_damage_multiplier = 0.7


### PR DESCRIPTION
## About The Pull Request
The original tower shield was literally unbreakable and had a near-full block chance for some reason. Encouraged an unfun and ridiculous meta that most players besides the ones who abuse the unbreakable shield mechanic wants gone away. The only shields left are tower shields, which have a durability system. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
del: Removes the Tower Shield from the game. That's it. That's the entire PR. 
/:cl:

