### PR TITLE
Removes EMP Function on Proton Axe

### DIFF
--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -548,13 +548,6 @@
 	throwforce = 15
 	throwforce_on = 30
 	attack_speed = CLICK_CD_MELEE * 1.25
-	var/emp_radius = 1
-
-/obj/item/melee/transforming/energy/axe/protonaxe/afterattack(atom/A, mob/living/user, proximity)
-	. = ..()
-	if(!active)
-		return
-	empulse_using_range(A, emp_radius, log=0) //fox go a (A)
 
 //dan kelly is a nerd NO YOU ARE!!!
 


### PR DESCRIPTION
## About The Pull Request
Big thanks to Chappy for abusing the proton axe's EMP function in his powergamer kit so we could remove it from the game.

Takes out the EMP spam from the proton axe. Not only incredibly broken but also spams the ghostchat with EMP explosion notifications. 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
del: Removes proton axe EMP
/:cl:

