### PR TITLE
Restores broken Tribal Recipes, removes CB slop arrow code

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -88,7 +88,7 @@
 //#define CAT_FURNITURE	"Burial & Execution"
 //#define CAT_FARMING	"Farming"
 #define CAT_PRIMAL	"Primal"
-//#define CAT_TRIBAL "Tribal"
+#define CAT_TRIBAL "Tribal"
 #define CAT_CLOTHING	"Clothing"
 #define CAT_FOOD	"Foods"
 #define CAT_WASTEFOOD	"Food Wasteland"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -307,7 +307,8 @@
 #define TRAIT_TECHNOPHOBE		"luddite" //Cannot use autolathes/biogens
 #define TRAIT_NODRUGS		"winners_cant_do_drugs" //drugs hurt you!
 #define TRAIT_LONGPORKLOVER		"Cannibal" //guess
-#define TRAIT_TRIBAL			"Tribalistic Person" //has access to tribal crafting recipes
+#define TRAIT_TRIBAL			"Tribalistic Person" //has access to some primal crafting recipes
+#define TRAIT_FULLTRIBAL		"Far-Lands Tribal" //has access to the entire tribal crafting recipes instead of the rudimentary primal ones
 #define TRAIT_BERSERKER			"berserker" //currently unused
 #define TRAIT_TECHNOPHREAK		"technophreak"	//boosts salvage return
 #define TRAIT_WEAPONCRAFTING	"weapon_crafting"	// You spawn with various unlocked gun/armor crafts

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -233,7 +233,7 @@
 	category = CAT_PRIMAL
 	always_available = FALSE
 
-/*
+
 /datum/crafting_recipe/tribalwar/sturdybow
 	name = "Sturdy Bow"
 	result = /obj/item/gun/ballistic/bow/sturdy
@@ -297,7 +297,6 @@
 				/obj/item/advanced_crafting_components/alloys = 1,
 				/obj/item/stack/sheet/glass = 4)
 	category = CAT_PRIMAL
-*/
 
 /datum/crafting_recipe/tribalwar/sling
 	name = "Sling"

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -318,7 +318,7 @@
 
 //ARROWS
 
-/* /datum/crafting_recipe/tribalwar/arrowburn
+/datum/crafting_recipe/tribalwar/arrowburn
 	name = "Burning Oil Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/burning
 	time = 30
@@ -429,7 +429,7 @@
 	category = CAT_PRIMAL
 	tools = list(TOOL_WORKBENCH)
 	always_available = TRUE
- */
+
 //MELEE
 
 /datum/crafting_recipe/tribalwar/bonespear

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -212,6 +212,7 @@
 	category = CAT_PRIMAL
 	always_available = TRUE
 
+/*
 datum/crafting_recipe/voodoo
 	name = "Voodoo"
 	result = /obj/item/reagent_containers/pill/patch/voodoo
@@ -223,7 +224,9 @@ datum/crafting_recipe/voodoo
 	category = CAT_PRIMAL
 	subcategory = CAT_PRIMAL
 	always_available = TRUE
+*/
 
+/*
 /datum/crafting_recipe/coyotechew
 	name = "Coyote Tobacco Chew"
 	result = /obj/item/reagent_containers/pill/patch/coyotechew
@@ -233,7 +236,7 @@ datum/crafting_recipe/voodoo
 	category = CAT_PRIMAL
 	subcategory = CAT_PRIMAL
 	always_available = TRUE
-
+*/
 
 //White Legs
 /datum/crafting_recipe/tribalwar/whitelegs

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -17,7 +17,7 @@
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/animalhide/deathclaw = 1) //changed from goliath to deathclaw
-	always_available = FALSE
+	always_available = TRUE
 
 /datum/crafting_recipe/tribalwar/bracers
 	name = "Bone Bracers"
@@ -25,7 +25,7 @@
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 1)
-	always_available = FALSE
+	always_available = TRUE
 
 //WEAPONS//
 
@@ -34,7 +34,7 @@
 	result = /obj/item/gun/syringe/blowgun
 	time = 50
 	reqs = list(/obj/item/stack/sheet/mineral/bamboo = 10)
-	always_available = FALSE
+	always_available = TRUE
 
 /datum/crafting_recipe/tribalwar/bow
 	name = "Short Bow"
@@ -92,7 +92,7 @@
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 1)
-	always_available = FALSE
+	always_available = TRUE
 */
 /datum/crafting_recipe/tribal/bonebag
 	name = "Tribal Satchel"
@@ -200,7 +200,7 @@
 				/obj/item/pestle = 1,
 				/obj/item/reagent_containers/glass/mortar = 1)
 	category = CAT_PRIMAL
-	always_available = FALSE
+	always_available = TRUE
 
 /datum/crafting_recipe/warmace
 	name = "Carve Wooden Warmace"
@@ -210,9 +210,9 @@
 				/obj/item/stack/sheet/cloth = 3)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_PRIMAL
-	always_available = FALSE
+	always_available = TRUE
 
-/*datum/crafting_recipe/voodoo
+datum/crafting_recipe/voodoo
 	name = "Voodoo"
 	result = /obj/item/reagent_containers/pill/patch/voodoo
 	time = 20
@@ -222,7 +222,7 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_PRIMAL
 	subcategory = CAT_PRIMAL
-	always_available = FALSE
+	always_available = TRUE
 
 /datum/crafting_recipe/coyotechew
 	name = "Coyote Tobacco Chew"
@@ -232,8 +232,8 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_PRIMAL
 	subcategory = CAT_PRIMAL
-	always_available = FALSE
-*/
+	always_available = TRUE
+
 
 //White Legs
 /datum/crafting_recipe/tribalwar/whitelegs
@@ -474,7 +474,7 @@ datum/crafting_recipe/tribalwar/bone
 // Western' Wayfarers
 
 /datum/crafting_recipe/tribalwar/wayfarers
-	always_available = FALSE
+	always_available = TRUE
 
 /datum/crafting_recipe/tribalwar/wayfarers/lightarmour
 	name = "Wayfarers Light Armour"

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -252,6 +252,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/*
 /datum/crafting_recipe/field_arrow
 	name = "Field Arrow"
 	result = /obj/item/stack/arrowhead/field
@@ -291,6 +292,7 @@
 	time = 30
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+*/
 
 /////////////////
 ///ammo        //

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(tribal_recipes, list(
 	/datum/crafting_recipe/tribalwar/bonespear,
 	/datum/crafting_recipe/tribalwar/bonecodpiece,
 	/datum/crafting_recipe/tribalwar/bracers,
-	/datum/crafting_recipe/tribal/bonetalisman,
+	//datum/crafting_recipe/tribal/bonetalisman,
 	/datum/crafting_recipe/spearfisher,
 	/datum/crafting_recipe/bitterdrink,
 	/datum/crafting_recipe/bitterdrink5,

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -134,6 +134,45 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 	/datum/crafting_recipe/tribalwar/bone/garb,
 	/datum/crafting_recipe/tribalwar/bone/helmet))
 
+GLOBAL_LIST_INIT(tribal_recipes, list(
+	/datum/crafting_recipe/tribal_pa,
+	/datum/crafting_recipe/tribal_pa_helmet,
+	/datum/crafting_recipe/tribal_combat_armor,
+	/datum/crafting_recipe/tribal_combat_armor_helmet,
+	/datum/crafting_recipe/tribal_r_combat_armor,
+	/datum/crafting_recipe/tribal_r_combat_armor_helmet,
+	/datum/crafting_recipe/tribalwar/chitinarmor,
+	/datum/crafting_recipe/tribalwar/lightcloak,
+	/datum/crafting_recipe/warmace,
+	/datum/crafting_recipe/tribalwar/lighttribe,
+	/datum/crafting_recipe/tribalwar/heavytribe,
+	/datum/crafting_recipe/tribalwar/legendaryclawcloak,
+	/datum/crafting_recipe/tribalwar/deathclawspear,
+	/datum/crafting_recipe/warpaint,
+	/datum/crafting_recipe/tribalradio,
+	/datum/crafting_recipe/tribalwar/goliathcloak,
+	/datum/crafting_recipe/tribalwar/bonebow,
+	/datum/crafting_recipe/tribalwar/tribe_bow,
+	/datum/crafting_recipe/tribalwar/sturdybow,
+	/datum/crafting_recipe/tribalwar/warclub,
+	/datum/crafting_recipe/tribalwar/silverbow,
+	/datum/crafting_recipe/tribalwar/arrowbone,
+	/datum/crafting_recipe/tribalwar/arrowemp,
+	/datum/crafting_recipe/tribalwar/bonespear,
+	/datum/crafting_recipe/tribalwar/bonecodpiece,
+	/datum/crafting_recipe/tribalwar/bracers,
+	/datum/crafting_recipe/tribal/bonetalisman,
+	/datum/crafting_recipe/spearfisher,
+	/datum/crafting_recipe/bitterdrink,
+	/datum/crafting_recipe/bitterdrink5,
+	/datum/crafting_recipe/healpoultice,
+	/datum/crafting_recipe/healpoultice5,
+	//datum/crafting_recipe/redpotion,
+	//datum/crafting_recipe/bluepotion,
+	//datum/crafting_recipe/greenpotion,
+	/datum/crafting_recipe/food/pemmican,
+	/datum/crafting_recipe/tribal/bonebag))
+
 //predominantly positive traits
 //this file is named weirdly so that positive traits are listed above negative ones
 
@@ -166,6 +205,28 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 		var/datum/species/species = H.dna.species
 		species.liked_food &= ~LONGPORK
 		species.disliked_food |= LONGPORK
+
+/datum/quirk/fulltribal
+	name = "Far-Lands Tribal
+	desc = "You are a proud member of a Far-Lands tribe, and have fully maintained their traditions. You do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe."
+	value = 1
+	gain_text = span_notice("You feel the rush of ancient knowledge rush through your loins...")
+	lose_text = span_notice("You suddenly feel a sneering superiority to knuckle-dragging facepainters.")
+
+/datum/quirk/fulltribal/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, "Former Tribal")
+	ADD_TRAIT(H, TRAIT_FULLTRIBAL, "Former Tribal")
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.tribal_recipes
+
+/datum/quirk/fulltribal/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(!QDELETED(H))
+		REMOVE_TRAIT(H, TRAIT_MACHINE_SPIRITS, "Former Tribal")
+		REMOVE_TRAIT(H, TRAIT_TRIBAL, "Former Tribal")
+		H.mind.learned_recipes -= GLOB.weaponcrafting_gun_recipes
 
 /datum/quirk/tribal
 	name = "Former Tribal"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(tribal_recipes, list(
 		species.disliked_food |= LONGPORK
 
 /datum/quirk/fulltribal
-	name = "Far-Lands Tribal
+	name = "Far-Lands Tribal"
 	desc = "You are a proud member of a Far-Lands tribe, and have fully maintained their traditions. You do what needs to be done to ensure the survival of yourself and your people while following the laws of the tribe."
 	value = 1
 	gain_text = span_notice("You feel the rush of ancient knowledge rush through your loins...")

--- a/code/game/objects/items/arrow_crafting.dm
+++ b/code/game/objects/items/arrow_crafting.dm
@@ -1,5 +1,5 @@
 /// ARROW CRAFTING ~
-
+/*
 /// the stickthing that we're using as a base that everything will be slapped onto
 /obj/item/arrow_shaft
 	name = "arrow shaft"
@@ -228,4 +228,4 @@
 	icon_state = "arrow_head_sticky"
 	merge_type = /obj/item/stack/arrowhead/sticky
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/sticky
-
+*/

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -52,10 +52,6 @@ GLOBAL_LIST_INIT(metalparts_recipes, list(\
 	))
 */
 
-/obj/item/stack/crafting/metalparts/get_main_recipes()
-	. = ..()
-	. += GLOB.metalparts_recipes
-
 /obj/item/stack/crafting/goodparts
 	name = "high quality metal parts"
 	icon_state = "sheet-goodparts"

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -46,9 +46,11 @@
 /obj/item/stack/crafting/metalparts/five
 	amount = 5
 
+/*
 GLOBAL_LIST_INIT(metalparts_recipes, list(\
 	new/datum/stack_recipe("jagged arrowhead", /obj/item/stack/arrowhead/jagged, 1, 1, 1 SECONDS),\
 	))
+*/
 
 /obj/item/stack/crafting/metalparts/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -15,7 +15,6 @@
 GLOBAL_LIST_INIT(glass_recipes, list ( \
 	new/datum/stack_recipe("directional window", /obj/structure/window/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile window", /obj/structure/window/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe("glass arrowhead", /obj/item/stack/arrowhead/glass, 1, 1, time = 2 SECONDS), \
 	null, \
 	new/datum/stack_recipe_list("glass working bases", list( \
 		new/datum/stack_recipe("chem dish", /obj/item/glasswork/glass_base/dish, 10), \

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -29,7 +29,6 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("drying rack", /obj/machinery/smartfridge/drying_rack, 10, one_per_turf = 1, on_floor = 1), \
 	null, \
 	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("flint arrowhead", /obj/item/stack/arrowhead/flint, 2, 1, time = 2.5 SECONDS), \
 	new/datum/stack_recipe("aesthetic volcanic floor tile", /obj/item/stack/tile/basalt, 2, 2, 4, 20), \
 	new/datum/stack_recipe("Assistant Statue", /obj/structure/statue/sandstone/assistant, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = 0, on_floor = 1) \
@@ -327,7 +326,6 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 GLOBAL_LIST_INIT(titanium_recipes, list ( \
 	new/datum/stack_recipe("titanium tile", /obj/item/stack/tile/mineral/titanium, 1, 4, 20), \
 	new/datum/stack_recipe("titanic ingot", /obj/item/blacksmith/ingot/titanium, 6, time = 100), \
-	new/datum/stack_recipe("titanium arrowhead", /obj/item/stack/arrowhead/titanium, 2, 1, time = 2.5 SECONDS), \
 	new/datum/stack_recipe("bear trap", /obj/item/restraints/legcuffs/beartrap, 1, time = 50), \
 	/*new/datum/stack_recipe("high quality parts", /obj/item/stack/crafting/goodparts, 5, time = 50) \ these are easy enough to find*/
 	))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -30,8 +30,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("iron ingot", /obj/item/blacksmith/ingot/iron, 6, time = 100), \
 	new/datum/stack_recipe("metal parts", /obj/item/stack/crafting/metalparts, 5), \
 	new/datum/stack_recipe("length of chain", /obj/item/blacksmith/chain, 1, time = 50), \
-	new/datum/stack_recipe("metal arrowhead", /obj/item/stack/arrowhead/metal, 2, 1, time = 2.5 SECONDS), \
-	new/datum/stack_recipe("field arrowhead", /obj/item/stack/arrowhead/field, 1, 1, time = 1 SECONDS), \
 	null, \
 	new/datum/stack_recipe("lock", /obj/item/lock_construct, 1), \
 	new/datum/stack_recipe("coffee pot", /obj/item/crafting/coffee_pot, 1), \
@@ -286,7 +284,6 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("wooden floor tile", /obj/item/stack/tile/wood, 1, 4, 20), \
-	new/datum/stack_recipe("wooden arrow shaft", /obj/item/arrow_shaft, 1, 1, 0.5 SECONDS, is_stack = FALSE), \
 	null, \
 	new/datum/stack_recipe_list("pews", list( \
 		new /datum/stack_recipe("pew (middle)", /obj/structure/chair/pew, 3, one_per_turf = TRUE, on_floor = TRUE),\
@@ -456,7 +453,6 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("salvage bag", /obj/item/storage/bag/salvage, 4), \
 	null, \
 	new/datum/stack_recipe("string", /obj/item/weaponcrafting/string, 1, time = 10), \
-	new/datum/stack_recipe("practice arrowhead", /obj/item/stack/arrowhead/practice, 1, 1, time = 1 SECONDS), \
 	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
 	new/datum/stack_recipe("improvised suture", /obj/item/stack/medical/suture/emergency, 3), \
 	new/datum/stack_recipe("rag", /obj/item/reagent_containers/rag, 1), \
@@ -794,7 +790,6 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 
 GLOBAL_LIST_INIT(bone_recipes, list(
 	new /datum/stack_recipe("bone dagger", /obj/item/melee/onehanded/knife/bone, 2, time = 20),
-	new /datum/stack_recipe("bone arrowhead", /obj/item/stack/arrowhead/bone, 2, 1, time = 2 SECONDS),
 	null, \
 	new /datum/stack_recipe("bone armor", /obj/item/clothing/suit/armor/light/tribal/bone, 6, time = 30),
 	new /datum/stack_recipe("skull helmet", /obj/item/clothing/head/helmet/skull, 4, time = 30),

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -29,10 +29,6 @@ GLOBAL_LIST_INIT(tape_recipes, list(\
 	))
 */
 
-/obj/item/stack/sticky_tape/get_main_recipes()
-	. = ..()
-	. += GLOB.tape_recipes
-
 /obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user)
 	if(!istype(I))
 		return

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -23,9 +23,11 @@
 	var/endless = FALSE
 	var/apply_time = 30
 
+/*
 GLOBAL_LIST_INIT(tape_recipes, list(\
 	new/datum/stack_recipe("sticky arrowhead", /obj/item/stack/arrowhead/sticky, 1, 1, 1 SECONDS),\
 	))
+*/
 
 /obj/item/stack/sticky_tape/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -511,7 +511,7 @@ obj/item/storage/bag/chemistry/tribal
 
 /obj/item/storage/bag/tribe_quiver/full/PopulateContents()
 	for(var/i in 1 to 12)
-		new /obj/item/ammo_casing/caseless/arrow/field(src)//12 total for now. just need one full one defined, for starting kits
+		new /obj/item/ammo_casing/caseless/arrow(src)//12 total for now. just need one full one defined, for starting kits
 
 /obj/item/storage/bag/tribe_quiver/light
 	name = "light quiver"
@@ -523,7 +523,7 @@ obj/item/storage/bag/chemistry/tribal
 
 /obj/item/storage/bag/tribe_quiver/light/full/PopulateContents()
 	for(var/i in 1 to 12)
-		new /obj/item/ammo_casing/caseless/arrow/field(src)//12 total for now. just need one full one defined, for starting kits
+		new /obj/item/ammo_casing/caseless/arrow(src)//12 total for now. just need one full one defined, for starting kits
 
 /obj/item/storage/bag/tribe_quiver/heavy
 	name = "back quiver"
@@ -536,7 +536,7 @@ obj/item/storage/bag/chemistry/tribal
 
 /obj/item/storage/bag/tribe_quiver/heavy/full/PopulateContents()
 	for(var/i in 1 to 12)
-		new /obj/item/ammo_casing/caseless/arrow/field(src)//12 total for now. just need one full one defined, for starting kits
+		new /obj/item/ammo_casing/caseless/arrow(src)//12 total for now. just need one full one defined, for starting kits
 
 /obj/item/storage/bag/tribe_quiver/AltClick(mob/living/carbon/user)
 	. = ..()

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -719,7 +719,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment(".308 stripper clip (5 bullets)",			/obj/item/ammo_box/a308,								6),
 		new /datum/data/wasteland_equipment(".30-06 stripper clip (5 bullets)",			/obj/item/ammo_box/a3006,								10),
 		new /datum/data/wasteland_equipment("Buckshot box (12 shells)",					/obj/item/ammo_box/shotgun/buck,						7),
-		new /datum/data/wasteland_equipment("Field Arrow (1 arrow)",					/obj/item/projectile/bullet/reusable/arrow/field,		3),
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment(".22 Pistol magazine (16 bullets)",			/obj/item/ammo_box/magazine/m22,						7),
@@ -731,7 +730,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment(".308 stripper clip (5 bullets)",			/obj/item/ammo_box/a308,								6),
 		new /datum/data/wasteland_equipment(".30-06 stripper clip (5 bullets)",			/obj/item/ammo_box/a3006,								10),
 		new /datum/data/wasteland_equipment("Buckshot box (12 shells)",					/obj/item/ammo_box/shotgun/buck,						7),
-		new /datum/data/wasteland_equipment("Field Arrow (1 arrow)",					/obj/item/projectile/bullet/reusable/arrow/field,		3),
 	)
 
 /obj/machinery/mineral/wasteland_vendor/clothing

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -1,3 +1,4 @@
+/*
 /obj/item/ammo_casing/caseless/arrow
 	name = "arrow"
 	desc = "a simple arrow with a metal head."
@@ -105,8 +106,9 @@
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT) //no sticky tape material type either. i cri
 	w_class = WEIGHT_CLASS_TINY
 
+*/
 
-/* //FO13 arrows
+ //FO13 arrows
 /obj/item/ammo_casing/caseless/arrow
 	name = "metal arrow"
 	desc = "A simple arrow with a metal head."
@@ -201,4 +203,4 @@
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	desc = "An arrow with a sturdy cloth sack at the end of it, meant to incapacitate and knock out instead of kill. How merciful you are, aristocrat!"
 	icon_state = "arrow_stam"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/blunt */
+	projectile_type = /obj/item/projectile/bullet/reusable/arrow/blunt 

--- a/code/modules/projectiles/boxes_magazines/internal/bow.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/bow.dm
@@ -1,10 +1,10 @@
 /obj/item/ammo_box/magazine/internal/bow
 	name = "bow internal magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/field
+	ammo_type = /obj/item/ammo_casing/caseless/arrow/
 	caliber = list(CALIBER_ARROW)
 	max_ammo = 1
 
-/* unneeded bow quivers
+
 /obj/item/ammo_box/magazine/internal/bow/xbow
 	name = "crossbow magazine"
 	max_ammo = 3
@@ -13,7 +13,7 @@
 //Deathclaw Bow Ammo
 /obj/item/ammo_box/magazine/internal/bow/claw
 	name = "bow internal magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/field
+	ammo_type = /obj/item/ammo_casing/caseless/arrow/
 	max_ammo = 7 // 8 shots in total
 
 //Sturdy Bow Ammo
@@ -31,4 +31,4 @@
 //Crossbow Ammo
 /obj/item/ammo_box/magazine/internal/bow/cross
 	max_ammo = 3 // 4 shots in total
-*/
+

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -283,7 +283,7 @@
 	)
 
 // Special bows?
-/* maybe at some point
+
 /obj/item/gun/ballistic/bow/gold
 	name = "golden bow"
 	desc = "A firm sturdy golden bow created by the earth, its smooth metal and strong grip allows for swift firing rates."
@@ -296,8 +296,8 @@
 	init_firemodes = list(
 			/datum/firemode/semi_auto/slow
 	)
-*/
-/* old bows, stinky, like fenny
+
+
 /obj/item/gun/ballistic/bow/xbow
 	name = "magazine-fed crossbow"
 	desc = "A somewhat primitive projectile weapon. Has a spring-loaded magazine, but still requires drawing back before firing. Fires arrows slightly faster than regular bows, improving damage"
@@ -366,6 +366,7 @@
 	fire_delay = 1.5
 	extra_speed = 100
 
+/*
 //Crossbow
 /obj/item/gun/ballistic/bow/crossbow
 	name = "crossbow"

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -1,3 +1,4 @@
+/*
 /obj/item/projectile/bullet/reusable/arrow
 	name = "arrow"
 	desc = "a simple arrow."
@@ -168,8 +169,7 @@
 	break_chance = 5 //real sturdy. this is the easy to make and supply "handload" of the arrow world
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/field
 
-/* I...don't really wanna touch this till nonlethal ammo is looked at, or I understand it. but should be sorta equivalent to a .308?
-*/
+
 /obj/item/projectile/bullet/reusable/arrow/blunt
 	name = "blunt arrow"
 	desc = "an arrow with a wrapped leather tip, made for bruising."
@@ -242,7 +242,7 @@
 		)
 
 
-/* 
+*/ 
 
 /obj/item/projectile/bullet/reusable/arrow
 	name = "metal arrow"
@@ -387,4 +387,4 @@
 	emp_radius = 1
 	damage = 20
 	armour_penetration = 0.5
- */
+ 


### PR DESCRIPTION
## About The Pull Request
Some codemonkey removed all the tribal recipes from the entire game, so I restored them, and added the Far-Lands tribal quirk to unlock all the old tribal recipes. 

I also brought back the old arrows from pre-rebase, since CB arrows are actual dookie dogshit. Arrows should be competitive with mid-to-high tier rifles now with the right skills. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Added a new tribal quirk, restored previous tribal recipes. 
add: Added back the old bows and arrows over the current ones. 
del: Removed CB slop code regarding arrow crafting and arrows.

/:cl:
