### PR TITLE
Bringing back niche ammo types to the field

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -345,6 +345,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+
 /*
 /datum/crafting_recipe/c38boxincin
 	name = ".38 incendiary-tipped ammo box"
@@ -359,6 +360,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 */
+
 /datum/crafting_recipe/c10mmincin
 	name = "10mm incendiary-tipped ammo box"
 	result = /obj/item/ammo_box/c10mm/fire
@@ -464,7 +466,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-/*
+
 /datum/crafting_recipe/a556uranium
 	name = "5.56mm uranium-tipped ammo box"
 	result = /obj/item/ammo_box/a556/uraniumtipped
@@ -478,8 +480,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-*/
-/*
+
 /datum/crafting_recipe/a762boxirr
 	name = "7.62 U-235 ammo box"
 	result = /obj/item/ammo_box/a762box/uraniumtipped
@@ -493,8 +494,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-*/
-/*
+
 /datum/crafting_recipe/a762boxshrap
 	name = "7.62mm micro-shrapnel ammo box"
 	result = /obj/item/ammo_box/a762box/microshrapnel
@@ -507,8 +507,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-*/
-/*
+
 /datum/crafting_recipe/a50MGboxuranium
 	name = "12.7mm U-235 ammo box"
 	result = /obj/item/ammo_box/a50MGbox/uraniumtipped
@@ -522,7 +521,6 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
-*/
 
 /datum/crafting_recipe/a50MGboxcontaminated
 	name = "12.7mm contaminated ammo box"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -413,7 +413,6 @@
 	desc = "Now with fragments!"
 	ammo_type = /obj/item/ammo_casing/a556/microshrapnel
 
-/*
 /obj/item/ammo_box/a556/uraniumtipped
 	name = "ammo box (5.56 uranium-tipped)"
 	desc = "Not depleted uranium. Regular uranium."
@@ -428,7 +427,6 @@
 /obj/item/ammo_box/a762box/uraniumtipped/Destroy()
 	STOP_PROCESSING(SSradiation,src)
 	..()
-*/
 
 /obj/item/ammo_box/a556/improvised
 	name = "bag with reloaded 5.56 bullets"
@@ -484,7 +482,7 @@
 	icon_state = "improvshotbag"
 	max_ammo = 15
 	multiple_sprites = 3
-/*
+
 /obj/item/ammo_box/a762box
 	name = "ammo box (7.62x51 FMJ Match)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
@@ -521,7 +519,7 @@
 	icon_state = "762box"
 	multiple_sprites = 2
 	ammo_type = /obj/item/ammo_casing/a308/rubber
-*/
+
 
 //.50 MG and 14mm
 /obj/item/ammo_box/a50MGbox
@@ -555,13 +553,11 @@
 	desc = "12.7mm bullets loaded with a gaseous hepatoxic payload, which reduces the effectiveness of medicine and toxins."
 	ammo_type = /obj/item/ammo_casing/a50MG/contam
 
-/*
 /obj/item/ammo_box/a50MGbox/uraniumtipped
 	name = "ammo box (12.7mm uranium-tipped)"
 	max_ammo = 15
 	desc = "12.7mm bullets loaded with enriched-uranium penetrators."
 	ammo_type = /obj/item/ammo_casing/a50MG/uraniumtipped
-*/
 
 /obj/item/ammo_box/m14mm
 	name = "ammo box (14mm)"
@@ -606,11 +602,9 @@
 	name = "ammo box (4.73mm incendiary)"
 	ammo_type = /obj/item/ammo_casing/caseless/g11/incendiary
 
-/*
 /obj/item/ammo_box/m473/uraniumtipped
 	name = "ammo box (4.73mm uranium-tipped)"
 	ammo_type = /obj/item/ammo_casing/caseless/g11/uraniumtipped
-*/
 
 /obj/item/ammo_box/m473/dumdum
 	name = "ammo box (4.73mm flat-nose)"
@@ -1013,7 +1007,6 @@
 	max_ammo = 5
 	multiple_sprites = 1
 
-
 /obj/item/ammo_box/a50MG/explosive
 	name = "anti-materiel explosive ammo rack (.50MG)"
 	desc = "5 rounds of explosive .50 MG. More then enough to kill anything that moves."
@@ -1028,13 +1021,11 @@
 	ammo_type = /obj/item/ammo_casing/a50MG/penetrator
 	icon_state = "50ap"
 
-/*
 /obj/item/ammo_box/a50MG/uraniumtipped
 	name = "anti-materiel uranium-tipped ammo rack (.50MG)"
 	desc = "5 rounds of uranium-tipped .50 MG, when you really want something to remember what it was like back in '77.'"
 	ammo_type = /obj/item/ammo_casing/a50MG/uraniumtipped
 	icon_state = "50ap"
-*/
 
 ////////////////////////////////
 // FLAMER FUEL AND OTHER MISC //


### PR DESCRIPTION
## About The Pull Request
You can crat incendiary/depleted uranium ammo types now to commit some extra heinous war crimes. Rejoice, NCR. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Readded uranium-tipped and incendiary munitions for various rifle types. 
/:cl:

