### PR TITLE
Adjust: Remove Balitmore from Rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -19,7 +19,7 @@ map pahrump-only
 endmap
 
 map baltimore
-    voteweight 1
+    disabled
 endmap
 
 map tipton


### PR DESCRIPTION
## About The Pull Request
WARNING THIS IS HALF TESTED, but should work. 
Removes balitmore from rotation, meaning it wont ever be selected again until it is reworked.
![image](https://github.com/user-attachments/assets/19a6861a-1673-4192-bc23-2b4f68c32490)


## Changelog
:cl:
adjusted: maps.txt config. 🤡 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
