### PR TITLE
Removal of combat vehicules on Pahrump

### DIFF
--- a/_maps/map_files/Pahrump-AB/Pahrump-AB-Upper.dmm
+++ b/_maps/map_files/Pahrump-AB/Pahrump-AB-Upper.dmm
@@ -6395,10 +6395,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"jJY" = (
-/obj/mecha/working/normalvehicle/vertibird/ncr/loaded,
-/turf/open/floor/f13,
-/area/f13/ncr)
 "jLE" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/f13{
@@ -12810,10 +12806,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"tcF" = (
-/obj/mecha/working/normalvehicle/vertibird/brotherhood/loaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "tcW" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood_fancy/wood_fancy_light,
@@ -15324,10 +15316,6 @@
 /obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/dorms)
-"xcf" = (
-/obj/mecha/working/normalvehicle/vertibird/balloon/loaded,
-/turf/open/floor/wood_common,
-/area/f13/wasteland)
 "xcA" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -23778,7 +23766,7 @@ ssV
 ssV
 cBM
 cBM
-jJY
+hIu
 cBM
 cBM
 ssV
@@ -57413,7 +57401,7 @@ igk
 ciQ
 ciQ
 ciQ
-tcF
+ciQ
 ciQ
 ciQ
 ciQ
@@ -58955,7 +58943,7 @@ igk
 ciQ
 ciQ
 ciQ
-tcF
+ciQ
 ciQ
 igk
 igk
@@ -70997,7 +70985,7 @@ xJg
 xJg
 xJg
 spS
-xcf
+spS
 spS
 oez
 oez

--- a/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
+++ b/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
@@ -26999,12 +26999,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fdT" = (
-/obj/mecha/working/normalvehicle/buggy/ranger/loaded,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland)
 "fdY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -28808,6 +28802,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"fPE" = (
+/obj/mecha/working/normalvehicle/corvega/loaded,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/city)
 "fPH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -40463,15 +40461,6 @@
 "kIz" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/ncr)
-"kID" = (
-/obj/effect/decal/marking{
-	icon_state = "dottedverticalcorroded"
-	},
-/obj/mecha/combat/combatvehicle/buggy/rangerarmed/loaded,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
 "kIJ" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47198,6 +47187,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"nox" = (
+/obj/mecha/working/normalvehicle/buggy/ranger/loaded,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "noC" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -48757,7 +48750,7 @@
 	},
 /area/f13/wasteland)
 "nXq" = (
-/obj/mecha/combat/combatvehicle/pickuptruck/bos/armed,
+/obj/mecha/working/normalvehicle/pickuptruck/bos,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "nXv" = (
@@ -61902,7 +61895,6 @@
 /area/f13/city)
 "tzu" = (
 /obj/structure/flora/branch,
-/obj/mecha/combat/combatvehicle/buggy/legionarmed/loaded,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirtcorner"
@@ -80368,7 +80360,7 @@ kLl
 esK
 aQZ
 mHp
-uNJ
+nox
 uNJ
 bMM
 qmG
@@ -80882,7 +80874,7 @@ kLl
 aqU
 aQZ
 mHp
-fdT
+bMM
 oXi
 jIk
 gPZ
@@ -81147,7 +81139,7 @@ hnE
 mHp
 bMM
 fiV
-kID
+bnK
 jIk
 tnZ
 tnZ
@@ -98492,7 +98484,7 @@ ueV
 aky
 xCv
 jkB
-jkB
+fPE
 jkB
 iht
 hKI


### PR DESCRIPTION
## About The Pull Request

Balance aint currently the best vehicule wise. 
As a temporary fix, this removes combat vehicles.

Normaly, after staff meeting, vehicles were supposed to be removed, but it seems that some people still like them.

Vertbirds, and legion balloons were removed from Pahrump, same for the Ranger Buggy and Legion Chariot