### PR TITLE
Bug FIx: Hunting Rifle ammo spawn

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1002,7 +1002,7 @@
 	name = "hunting rifle and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/rifle/hunting,
-				/obj/item/ammo_box/a308
+				/obj/item/ammo_box/a3006
 				)
 
 /obj/effect/spawner/bundle/f13/n99


### PR DESCRIPTION
## About The Pull Request
This is for the hunting rifle spawns so it comes with .30-06 not .308 someone pointed it out and now its squashed.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: hunting rifle spawns with 30-06.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
