### PR TITLE
Map Fix: Area Alligment Pahrump

### DIFF
--- a/_maps/map_files/Pahrump-AB/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-AB/Dungeons.dmm
@@ -142,7 +142,7 @@
 	dir = 1
 	},
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "adn" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -282,13 +282,13 @@
 "agL" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "agN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "agO" = (
 /obj/machinery/light{
 	dir = 4;
@@ -318,7 +318,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ahN" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -387,7 +387,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ajp" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -407,7 +407,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ajz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -442,7 +442,7 @@
 /obj/item/mine/shrapnel,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "alf" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/rag/towel{
@@ -482,7 +482,7 @@
 /obj/structure/closet/crate/rcd,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "alt" = (
 /mob/living/simple_animal/hostile/raider/cultist/melee,
 /turf/open/floor/grass,
@@ -521,7 +521,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "alK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -590,14 +590,14 @@
 	},
 /obj/structure/glowshroom,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ann" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "anv" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -632,7 +632,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aol" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
@@ -646,7 +646,7 @@
 "apd" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "apu" = (
 /obj/machinery/light{
 	dir = 4
@@ -661,7 +661,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "apX" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -690,7 +690,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aqK" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/f13/usscientist,
@@ -702,7 +702,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "arb" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -810,7 +810,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "asG" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -864,7 +864,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "atp" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -905,7 +905,7 @@
 "auw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "auA" = (
 /obj/machinery/button/door{
 	id = "bosfrontgate";
@@ -943,7 +943,7 @@
 	},
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "avj" = (
 /obj/structure/decoration/sign{
 	desc = "It's a portrait of a person you don't know anything about.";
@@ -996,14 +996,14 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "awL" = (
 /obj/structure/table,
 /obj/item/ammo_box/c10mm,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "awT" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
@@ -1132,7 +1132,7 @@
 "aAs" = (
 /obj/structure/nest/tunneler,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aAv" = (
 /obj/structure/toilet{
 	dir = 4
@@ -1367,7 +1367,7 @@
 	name = "assaultron dominator"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aJA" = (
 /obj/effect/decal/cleanable/ash/crematorium,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -1388,7 +1388,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aKV" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/reinforced,
@@ -1477,7 +1477,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aME" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -1485,7 +1485,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aMS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -1499,7 +1499,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aNf" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/effect/decal/cleanable/dirt,
@@ -1507,7 +1507,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aNg" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /mob/living/simple_animal/hostile/radscorpion,
@@ -1518,7 +1518,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aOl" = (
 /obj/item/ship_in_a_bottle{
 	pixel_x = -5;
@@ -1579,7 +1579,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aPi" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
@@ -1625,7 +1625,7 @@
 /obj/effect/decal/remains/human,
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aPK" = (
 /obj/machinery/light/floor,
 /obj/structure/lattice{
@@ -1700,7 +1700,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aSl" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1847,7 +1847,7 @@
 	},
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "aVD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/big{
@@ -2047,7 +2047,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bcC" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -2120,7 +2120,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bex" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -2179,7 +2179,7 @@
 /area/f13/underground/cave)
 "bfM" = (
 /turf/closed/wall/f13/wood,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bfR" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating{
 	name = "plating"
@@ -2395,7 +2395,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "blc" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/crafting/abraxo,
@@ -2546,7 +2546,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bpX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/gib,
@@ -2556,7 +2556,7 @@
 /obj/structure/barricade/sandbags,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bqd" = (
 /obj/machinery/light,
 /obj/structure/lattice{
@@ -2573,7 +2573,7 @@
 	name = "ancient ladder"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bqg" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -2605,7 +2605,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "brc" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/arrows{
@@ -2713,7 +2713,7 @@
 "btQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "btT" = (
 /mob/living/simple_animal/hostile/enclave,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2807,7 +2807,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bwF" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -2821,7 +2821,7 @@
 /obj/item/stack/sheet/mineral/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bxk" = (
 /obj/effect/spawner/lootdrop/f13/weapon/milsurplus,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -2931,7 +2931,7 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bzR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2950,7 +2950,7 @@
 /obj/structure/bed/old,
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bAz" = (
 /obj/machinery/door/window/right,
 /turf/open/floor/plasteel/f13{
@@ -2963,7 +2963,7 @@
 	pixel_x = -16
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bAM" = (
 /obj/structure/closet/crate/secure/weapon,
 /turf/open/floor/plasteel/barber{
@@ -3022,7 +3022,7 @@
 "bCx" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/wall/f13/tunnel,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bCH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -3049,7 +3049,7 @@
 /obj/item/seeds/ambrosia/gaia,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bDl" = (
 /obj/structure/sink{
 	dir = 8;
@@ -3092,7 +3092,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bFm" = (
 /obj/structure/obstacle/barbedwire/end,
 /obj/effect/turf_decal/weather/dirt{
@@ -3138,7 +3138,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bFQ" = (
 /obj/structure/bed/roller,
 /obj/structure/cable{
@@ -3217,7 +3217,7 @@
 "bIR" = (
 /obj/structure/timeddoor/threehours,
 /turf/closed/mineral/random/low_chance,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bJa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3227,7 +3227,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bJy" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -3244,7 +3244,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bJL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3435,7 +3435,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bPT" = (
 /obj/item/flashlight/lamp{
 	pixel_x = -3;
@@ -3526,7 +3526,7 @@
 "bRa" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bRj" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -3570,7 +3570,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bRJ" = (
 /mob/living/simple_animal/hostile/eyebot,
 /obj/machinery/shower{
@@ -3578,7 +3578,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bRK" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/barber{
@@ -3652,12 +3652,12 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bTw" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -3677,7 +3677,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bUl" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/river,
@@ -3715,7 +3715,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bVj" = (
 /obj/structure/sign/painting/library_secure{
 	persistence_id = "brotherhood_secure";
@@ -3802,7 +3802,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bYb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3814,7 +3814,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "bZi" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -3839,7 +3839,7 @@
 /area/f13/brotherhood/archives)
 "cab" = (
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "caf" = (
 /obj/machinery/chem_master/advanced,
 /obj/machinery/light,
@@ -4007,7 +4007,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cdZ" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
@@ -4164,7 +4164,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cif" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -4196,7 +4196,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ciW" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 4;
@@ -4284,7 +4284,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ckI" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -4384,7 +4384,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "coi" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -30
@@ -4404,7 +4404,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "coz" = (
 /obj/machinery/light{
 	dir = 1;
@@ -4436,7 +4436,7 @@
 	},
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cpZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 93
@@ -4518,7 +4518,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "csl" = (
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/building)
@@ -4536,7 +4536,7 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "csF" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	color = "#75705a";
@@ -4544,7 +4544,7 @@
 	name = "assaultron dominator"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cti" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -4576,7 +4576,7 @@
 	icon_state = "bloodpaw2"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cux" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -4604,7 +4604,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cvi" = (
 /obj/structure/debris/v2,
 /turf/open/floor/plasteel/elevatorshaft,
@@ -4641,7 +4641,7 @@
 "cwo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cws" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
@@ -4728,7 +4728,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cyz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -4751,7 +4751,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/armor/power_armor/t45d,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cyH" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -4772,7 +4772,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/engineering,
@@ -4793,7 +4793,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "czv" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -4989,7 +4989,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cDq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5017,7 +5017,7 @@
 	},
 /obj/structure/timeddoor/threehours,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cDS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5041,7 +5041,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cEb" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/vaultdoor,
@@ -5069,7 +5069,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cEy" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5133,7 +5133,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cGb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5160,7 +5160,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cGA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5421,7 +5421,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cLO" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood,
@@ -5448,7 +5448,7 @@
 /obj/structure/bed/mattress,
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cMu" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -5541,7 +5541,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cOA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/enclave/scientist,
@@ -5684,7 +5684,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cRm" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -5707,7 +5707,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cRC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6005,7 +6005,7 @@
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_bigboss,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "cZI" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable{
@@ -6048,7 +6048,7 @@
 	},
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "daP" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -6083,7 +6083,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dcp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/r_wall/rust,
@@ -6122,7 +6122,7 @@
 /obj/item/flashlight,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ddi" = (
 /obj/item/radio/intercom{
 	dir = 8
@@ -6232,7 +6232,7 @@
 	name = "assaultron dominator"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dfC" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -6319,7 +6319,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dhl" = (
 /obj/structure/table{
 	layer = 2.9
@@ -6360,7 +6360,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dhY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
@@ -6425,7 +6425,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "djm" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -6466,7 +6466,7 @@
 	icon_state = "trails_1"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "djN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6592,7 +6592,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dll" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plasteel/f13{
@@ -6641,7 +6641,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dmU" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6745,7 +6745,7 @@
 /obj/structure/spacevine,
 /obj/structure/junk/small/disco,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dpk" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -6760,7 +6760,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dpq" = (
 /mob/living/simple_animal/hostile/enclave,
 /turf/open/floor/holofloor/carpet,
@@ -6807,7 +6807,7 @@
 /obj/structure/table/rolling,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dpZ" = (
 /obj/structure/table/wood,
 /obj/item/circuitboard/machine/autolathe/ammo/improvised,
@@ -6850,7 +6850,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dqI" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6874,7 +6874,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "drk" = (
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/offices1st)
@@ -6947,7 +6947,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dsO" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/machinery/light/broken{
@@ -7053,7 +7053,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dvP" = (
 /obj/structure/debris/v2,
 /turf/open/floor/f13{
@@ -7141,11 +7141,11 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dyt" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/f13/tunnel,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dyu" = (
 /obj/machinery/light{
 	dir = 1
@@ -7186,7 +7186,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dzg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7261,7 +7261,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dCe" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
@@ -7304,7 +7304,7 @@
 	req_one_access_txt = "150"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dDc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -7424,7 +7424,7 @@
 	icon_state = "gibbearcore"
 	},
 /turf/closed/wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dFb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7504,7 +7504,7 @@
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dFY" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -7614,7 +7614,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dIP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7635,7 +7635,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dJh" = (
 /obj/item/instrument/guitar,
 /obj/structure/cable{
@@ -7690,7 +7690,7 @@
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dKo" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 9
@@ -7706,7 +7706,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dKy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/plants/portaseeder,
@@ -7730,7 +7730,7 @@
 "dKK" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dKR" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -7787,7 +7787,7 @@
 "dLC" = (
 /mob/living/simple_animal/hostile/trog/tunneler/blindone,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dLF" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -7860,7 +7860,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dMX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7877,7 +7877,7 @@
 "dNj" = (
 /obj/item/clothing/suit/armor/light/tribal/cloak,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dNq" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -7990,7 +7990,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dPO" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -8115,7 +8115,7 @@
 	randomizer_tag = "Radioshack Radicals"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dRW" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8151,7 +8151,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dSW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/decoration/fire,
@@ -8210,7 +8210,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dVe" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 6;
@@ -8233,7 +8233,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dVz" = (
 /obj/structure/window/reinforced{
 	color = "#3e3d42"
@@ -8251,7 +8251,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "dWc" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
@@ -8434,7 +8434,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eaL" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -8445,7 +8445,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eaW" = (
 /obj/effect/decal/remains/human,
 /obj/structure/closet,
@@ -8593,7 +8593,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "efq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8637,7 +8637,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "egc" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/r_wall,
@@ -8668,7 +8668,7 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "egq" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -8803,7 +8803,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ejr" = (
 /obj/machinery/light{
 	dir = 4
@@ -8825,7 +8825,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ekb" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -8870,7 +8870,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ely" = (
 /obj/item/am_containment{
 	pixel_x = 3
@@ -9015,7 +9015,7 @@
 	},
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eoR" = (
 /obj/item/ammo_casing/c9mm,
 /obj/machinery/door/poddoor/ert{
@@ -9039,7 +9039,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "epH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/camera_advanced/abductor{
@@ -9066,7 +9066,7 @@
 /obj/effect/decal/cleanable/robot_debris,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eqm" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -9158,7 +9158,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ers" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -9175,7 +9175,7 @@
 "erI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "erV" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9216,7 +9216,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "esJ" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -9374,7 +9374,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ewP" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9414,7 +9414,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/emptysandbags,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eyk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9543,7 +9543,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/enclave)
@@ -9559,7 +9559,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eBL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
@@ -9573,7 +9573,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eCd" = (
 /obj/machinery/light{
 	dir = 4
@@ -9678,7 +9678,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eED" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/fingerless,
@@ -9752,13 +9752,13 @@
 "eGM" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eGO" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/food,
 /obj/effect/spawner/lootdrop/food,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eHl" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "stagestairs2"
@@ -9770,7 +9770,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eIm" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -9882,7 +9882,7 @@
 /obj/item/stack/sheet/mineral/sandbags,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eMb" = (
 /obj/item/clothing/under/f13/vault{
 	desc = "A blue jumpsuit with a yellow vault pattern and the number 223 printed on it.";
@@ -9909,7 +9909,7 @@
 "eMf" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eMg" = (
 /obj/machinery/light/floor,
 /obj/item/radio/intercom{
@@ -9944,7 +9944,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eNs" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10024,7 +10024,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eOU" = (
 /obj/structure/chair/office/dark{
 	dir = 1;
@@ -10084,7 +10084,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eQu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10107,14 +10107,14 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eRb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eRD" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
@@ -10148,7 +10148,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eSA" = (
 /obj/machinery/light{
 	dir = 8
@@ -10183,7 +10183,7 @@
 /obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eTQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -10233,7 +10233,7 @@
 	name = "securitron mk.2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eUO" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
@@ -10311,7 +10311,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eVY" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -10377,7 +10377,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eYH" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -10456,7 +10456,7 @@
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/tribal,
 /obj/item/clothing/head/helmet/f13/combat/mk2/tribal,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "eZX" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -10613,7 +10613,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fdI" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
@@ -10631,7 +10631,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fez" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -10724,7 +10724,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fgX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass{
@@ -10768,7 +10768,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fjn" = (
 /obj/structure/lattice{
 	density = 1
@@ -10854,7 +10854,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fls" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/hooded/cloak/goliath,
@@ -10911,7 +10911,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fmA" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -10932,7 +10932,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fnS" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -10946,7 +10946,7 @@
 /obj/effect/spawner/lootdrop/high_tools,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "foy" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/stripes/box,
@@ -11043,7 +11043,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fqR" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -11096,7 +11096,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fsx" = (
 /obj/machinery/door/airlock/security{
 	name = "Gatehouse";
@@ -11149,7 +11149,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ftd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -11241,7 +11241,7 @@
 /obj/item/stack/medical/gauze,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fvu" = (
 /obj/machinery/light{
 	dir = 8
@@ -11302,7 +11302,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fyi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11407,7 +11407,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fBb" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/blood/old,
@@ -11432,7 +11432,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fCa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -11460,7 +11460,7 @@
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/food,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fDC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11490,7 +11490,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fDW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -11611,7 +11611,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fFV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11621,7 +11621,7 @@
 	name = "securitron mk.2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fFW" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = 30
@@ -11663,7 +11663,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fGo" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -11777,7 +11777,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fIW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12373,12 +12373,12 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fXV" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fXZ" = (
 /obj/structure/bed{
 	pixel_y = 7
@@ -12513,7 +12513,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "fZr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -12636,7 +12636,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gdc" = (
 /obj/structure/table/wood,
 /obj/item/crafting/board,
@@ -12671,7 +12671,7 @@
 /obj/effect/overlay/junk/oldpipes,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gdK" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -12695,7 +12695,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ges" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -12714,7 +12714,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "geX" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/m5mm,
@@ -12780,7 +12780,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gfJ" = (
 /obj/structure/destructible/clockwork/wall_gear,
 /turf/closed/indestructible/f13vaultrusted,
@@ -12797,7 +12797,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gfP" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -12865,7 +12865,7 @@
 	color = "#3c2c21"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ghk" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 20;
@@ -12908,7 +12908,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ghS" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/underground/cave)
@@ -12963,7 +12963,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gjE" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -13001,7 +13001,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gkb" = (
 /obj/machinery/light{
 	dir = 8
@@ -13052,7 +13052,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "glQ" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd5";
@@ -13136,7 +13136,7 @@
 	max_mobs = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "goN" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -13284,7 +13284,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gtx" = (
 /obj/structure/chair/f13chair1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -13423,7 +13423,7 @@
 	termtag = "Security"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gxg" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/structure/stone_tile/center,
@@ -13436,7 +13436,7 @@
 	faction = list("tunneler", "jungle")
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gxh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13459,7 +13459,7 @@
 "gxN" = (
 /mob/living/simple_animal/hostile/handy/robobrain,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gxX" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
@@ -13524,7 +13524,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gzO" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibup1"
@@ -13559,7 +13559,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gAG" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
@@ -13572,13 +13572,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gBg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gBk" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/dandyapples,
@@ -13655,7 +13655,7 @@
 "gCY" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gDe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13748,7 +13748,7 @@
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gEU" = (
 /obj/structure/table,
 /obj/item/scalpel,
@@ -13830,7 +13830,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gGM" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -14020,7 +14020,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gLK" = (
 /obj/structure/table{
 	layer = 2.9
@@ -14061,7 +14061,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gMO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14114,7 +14114,7 @@
 "gOx" = (
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gOU" = (
 /obj/machinery/light{
 	dir = 1
@@ -14237,7 +14237,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gSj" = (
 /turf/closed/indestructible/oldshuttle/corner{
 	color = "#808080";
@@ -14270,7 +14270,7 @@
 	dir = 4
 	},
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gSG" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/tunnel,
@@ -14310,7 +14310,7 @@
 "gTv" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/wall/r_wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gTw" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14335,7 +14335,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
@@ -14434,7 +14434,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gXp" = (
 /obj/structure/rack,
 /obj/item/crafting/frame,
@@ -14518,7 +14518,7 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gYX" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -14549,7 +14549,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "gZn" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -14592,7 +14592,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "haI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -14609,7 +14609,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "haR" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -14938,11 +14938,11 @@
 	},
 /area/f13/bunker)
 "hii" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/underground/cave)
+/turf/open/water,
+/area/f13/bunker)
 "hio" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -14983,7 +14983,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hjh" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/mining)
@@ -15080,7 +15080,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/ice,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hlU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15283,7 +15283,7 @@
 /obj/structure/chair/stool/retro/tan,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hqd" = (
 /turf/closed/wall/r_wall,
 /area/f13/caves)
@@ -15356,7 +15356,7 @@
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hsZ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -15683,7 +15683,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hCz" = (
 /obj/machinery/light/sign{
 	icon_state = "board_text6"
@@ -15783,7 +15783,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hDM" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15824,7 +15824,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hEY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15921,7 +15921,7 @@
 	id = "sunsetdung1"
 	},
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hHs" = (
 /turf/closed/indestructible/oldshuttle/corner{
 	color = "#808080";
@@ -16039,7 +16039,7 @@
 "hKY" = (
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hLc" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -16049,7 +16049,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hLv" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
@@ -16121,7 +16121,7 @@
 /obj/item/stack/ore/uranium,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hNI" = (
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -16132,7 +16132,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hNR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/light_emitter,
@@ -16164,7 +16164,7 @@
 /mob/living/simple_animal/hostile/handy/gutsy,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hOj" = (
 /obj/machinery/light{
 	dir = 1
@@ -16176,7 +16176,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hOL" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -16199,7 +16199,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hOR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -16224,7 +16224,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "hPQ" = (
 /obj/item/twohanded/sledgehammer/simple,
 /turf/closed/wall/r_wall,
@@ -16606,7 +16606,7 @@
 "iar" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iau" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -16625,7 +16625,7 @@
 	},
 /obj/structure/junk/jukebox,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iaT" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -16702,7 +16702,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iel" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -16871,7 +16871,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ijp" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science"
@@ -16882,8 +16882,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ijt" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/underground/cave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/bunker)
 "ijy" = (
 /obj/structure/table/wood,
 /obj/item/clothing/accessory/lawyers_badge,
@@ -16958,14 +16958,14 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ikW" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/chinese/ranged/assault,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ikX" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/enclave)
@@ -17097,7 +17097,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ipF" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17169,7 +17169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "irG" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -17194,7 +17194,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "isz" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
@@ -17212,21 +17212,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "isM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "isR" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "itj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/ert{
@@ -17262,7 +17262,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "itA" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -17280,7 +17280,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iug" = (
 /obj/structure/shelf_wood,
 /obj/item/binoculars,
@@ -17406,7 +17406,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iwu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -17433,7 +17433,7 @@
 /obj/effect/spawner/lootdrop/plush,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ixo" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17469,13 +17469,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ixP" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iyh" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
@@ -17488,7 +17488,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iyD" = (
 /obj/structure/table/wood,
 /obj/item/stock_parts/cell/high,
@@ -17504,7 +17504,7 @@
 "iyP" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iyV" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
@@ -17587,7 +17587,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iDb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17649,7 +17649,7 @@
 "iEC" = (
 /obj/structure/timeddoor/threehours,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iEF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -17694,7 +17694,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iFA" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -17869,7 +17869,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iKf" = (
 /obj/structure/toilet{
 	dir = 8
@@ -18024,7 +18024,7 @@
 /obj/structure/obstacle/barbedwire/end,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iNp" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/lattice/catwalk,
@@ -18048,7 +18048,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iNv" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel{
@@ -18082,7 +18082,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iOS" = (
 /obj/effect/turf_decal/big,
 /mob/living/simple_animal/hostile/enclave,
@@ -18175,7 +18175,7 @@
 "iRv" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iRY" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -18246,7 +18246,7 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iTc" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/f13{
@@ -18263,7 +18263,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iUa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18338,7 +18338,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iVU" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/toy/plush/lizardplushie,
@@ -18387,7 +18387,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iXT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18444,7 +18444,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iZc" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -18458,7 +18458,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iZs" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -18479,7 +18479,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "iZK" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 storage"
@@ -18552,7 +18552,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jbe" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -18655,7 +18655,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jdS" = (
 /obj/structure/lattice{
 	density = 1
@@ -18681,7 +18681,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jew" = (
 /obj/structure/destructible/clockwork/wall_gear,
 /obj/item/projectile/magic/animate,
@@ -18945,7 +18945,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jlg" = (
 /obj/machinery/libraryscanner{
 	desc = "This device scans books and other documents for entry into the Archives.";
@@ -18998,7 +18998,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jma" = (
 /obj/machinery/door/window/right/directional/east{
 	dir = 1
@@ -19112,7 +19112,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jpz" = (
 /obj/structure/fluff/railing{
 	dir = 8;
@@ -19123,7 +19123,7 @@
 "jpA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jpB" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -19136,7 +19136,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jpO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19163,10 +19163,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jqZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jrL" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -19200,7 +19200,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jtd" = (
 /mob/living/simple_animal/hostile/enclave/scientist,
 /turf/open/floor/f13{
@@ -19272,7 +19272,7 @@
 /obj/structure/stone_tile/center/burnt,
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jvG" = (
 /obj/structure/toilet/secret/high_loot{
 	dir = 8
@@ -19281,7 +19281,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jvU" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -19385,7 +19385,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jyu" = (
 /obj/item/trash,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -19395,7 +19395,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jyx" = (
 /obj/item/paper,
 /obj/item/pen,
@@ -19536,12 +19536,12 @@
 "jAq" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jAs" = (
 /obj/structure/closet/fridge,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jAB" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13{
@@ -19558,7 +19558,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jBt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
@@ -19616,7 +19616,7 @@
 	icon_state = "seclite"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jCL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line,
@@ -19665,7 +19665,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jEF" = (
 /mob/living/simple_animal/hostile/chinese/ranged,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19811,7 +19811,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jIh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -19828,7 +19828,7 @@
 /area/f13/brotherhood/offices2nd)
 "jIr" = (
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jID" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -19908,7 +19908,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jJG" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -19941,7 +19941,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jKl" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -20061,7 +20061,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jMj" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -20086,7 +20086,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jMu" = (
 /obj/machinery/door/airlock/command{
 	name = "Bot Control";
@@ -20165,7 +20165,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/photosynthetic,
@@ -20179,7 +20179,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jON" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -20232,7 +20232,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jQi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -20313,7 +20313,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jTv" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -20413,7 +20413,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jXP" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -20453,7 +20453,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "jZu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20524,7 +20524,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kaX" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/mineral/concrete,
@@ -20536,7 +20536,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kbm" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/broken{
@@ -20583,7 +20583,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kbV" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -20681,7 +20681,7 @@
 	icon_state = "seclite"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kdu" = (
 /obj/machinery/light{
 	dir = 8
@@ -20764,7 +20764,7 @@
 	name = "securitron mk.2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kfd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20791,11 +20791,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "kgs" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
-/area/f13/underground/cave)
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/bunker)
 "kgL" = (
 /obj/structure/debris/v2,
 /turf/open/floor/plasteel/elevatorshaft,
@@ -20846,7 +20843,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "khR" = (
 /obj/machinery/light{
 	dir = 8
@@ -20866,7 +20863,7 @@
 	icon_state = "trails_1"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kiH" = (
 /mob/living/simple_animal/hostile/fireant,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20968,7 +20965,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kln" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -20989,7 +20986,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "klN" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -21031,7 +21028,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kmr" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21053,7 +21050,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kmG" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/inside/dirt,
@@ -21070,7 +21067,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "knd" = (
 /obj/structure/falsewall/reinforced,
 /turf/open/floor/plasteel/barber{
@@ -21221,7 +21218,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kqq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21243,7 +21240,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kqG" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/mineral/concrete,
@@ -21338,7 +21335,7 @@
 	icon_state = "seclite"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ktn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21374,7 +21371,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ktJ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -21506,7 +21503,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kxa" = (
 /obj/item/radio/intercom{
 	dir = 4
@@ -21560,7 +21557,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kyO" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -21586,7 +21583,7 @@
 "kzv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kAe" = (
 /obj/effect/landmark/start/f13/overseer,
 /obj/structure/cable{
@@ -21817,12 +21814,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kFo" = (
 /obj/structure/bedsheetbin/empty,
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kFp" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -21830,7 +21827,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kFL" = (
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21895,7 +21892,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kHp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21993,14 +21990,14 @@
 /obj/item/stack/sheet/mineral/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kIS" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/gibs/human/torso,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kJa" = (
 /obj/structure/table{
 	layer = 2.9
@@ -22119,7 +22116,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kLq" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/radiation,
@@ -22336,7 +22333,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/soap,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kQq" = (
 /obj/machinery/autolathe,
 /obj/machinery/light{
@@ -22404,7 +22401,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kTT" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/stack/sheet/mineral/uranium{
@@ -22520,7 +22517,7 @@
 "kWz" = (
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kWB" = (
 /obj/structure/rack,
 /obj/item/airlock_painter,
@@ -22605,7 +22602,7 @@
 "kXF" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kXI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer1{
@@ -22631,7 +22628,7 @@
 "kXS" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/ice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kYc" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -22686,7 +22683,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kZl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22709,7 +22706,7 @@
 "kZK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "kZO" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
@@ -22795,7 +22792,7 @@
 "ldq" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ldy" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 1
@@ -22807,7 +22804,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "leh" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -22819,7 +22816,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ley" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -22829,7 +22826,7 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "leE" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -22935,7 +22932,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lhA" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -22969,7 +22966,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lig" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -23022,7 +23019,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ljP" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel,
@@ -23101,7 +23098,7 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lnj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23125,7 +23122,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lnG" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/box/ration/menu_two,
@@ -23133,7 +23130,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lnK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23149,7 +23146,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lod" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/f13{
@@ -23162,7 +23159,7 @@
 	},
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/plasteel/f13/vault_floor/green/corner,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lou" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -23241,7 +23238,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lpO" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/r_wall,
@@ -23261,7 +23258,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lqs" = (
 /obj/structure/table/wood,
 /obj/item/trash/f13/blamco_large,
@@ -23389,7 +23386,7 @@
 /obj/structure/grille,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lsJ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -23425,7 +23422,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ltS" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -23434,7 +23431,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ltW" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd5";
@@ -23490,7 +23487,7 @@
 "lwe" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lwl" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23503,7 +23500,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lwM" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker/bighornbunker)
@@ -23517,7 +23514,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lwW" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/armband/med,
@@ -23541,7 +23538,7 @@
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/ice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lxB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/f13{
@@ -23665,7 +23662,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lAi" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -23706,7 +23703,7 @@
 /area/f13/vault)
 "lBc" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lBg" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/f13,
@@ -23825,7 +23822,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lEF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -23843,7 +23840,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -23864,7 +23861,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lFk" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -23892,7 +23889,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lFJ" = (
 /obj/structure/table/wood/fancy/black{
 	desc = "A set of thin pipes that no longer function.";
@@ -23946,7 +23943,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lGn" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/barber{
@@ -24004,7 +24001,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lHJ" = (
 /mob/living/simple_animal/hostile/chinese,
 /turf/open/floor/plasteel/f13{
@@ -24017,7 +24014,7 @@
 "lIg" = (
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lIz" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod/dark,
@@ -24121,7 +24118,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lLE" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/slab,
@@ -24129,7 +24126,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lLK" = (
 /obj/structure/rack,
 /obj/item/storage/belt/army/security,
@@ -24235,7 +24232,7 @@
 /obj/item/kirbyplants/random,
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lPa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24276,7 +24273,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lPS" = (
 /obj/machinery/vending/robotics,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -24362,7 +24359,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lRw" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -24392,7 +24389,7 @@
 	name = "ancient turret"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lRP" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -24444,13 +24441,13 @@
 	name = "The Grill Sergeant"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lSJ" = (
 /obj/structure/flora/grass/coyote/eight,
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lTg" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -24519,7 +24516,7 @@
 	randomizer_tag = "Radioshack Radicals"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lVH" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24548,7 +24545,7 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "lXc" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -24710,7 +24707,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mak" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24735,7 +24732,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "maq" = (
 /obj/item/flashlight/seclite,
 /obj/item/clothing/head/ushanka,
@@ -24772,7 +24769,7 @@
 /area/f13/brotherhood/rnd)
 "maW" = (
 /turf/closed/indestructible/necropolis,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mbc" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkpurple/side,
@@ -24796,7 +24793,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mbA" = (
 /obj/structure/table{
 	layer = 2.9
@@ -24877,7 +24874,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mfu" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper,
@@ -24893,7 +24890,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mfE" = (
 /obj/item/stack/sheet/prewar/five,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -24905,7 +24902,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mfQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5;
@@ -25017,7 +25014,7 @@
 /obj/structure/closet/decay,
 /obj/effect/spawner/bundle/f13/armor/combat,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mhR" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/instamash,
@@ -25050,7 +25047,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "miW" = (
 /obj/machinery/flasher/portable,
 /obj/effect/decal/cleanable/dirt,
@@ -25105,7 +25102,7 @@
 	},
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mlc" = (
 /obj/structure/closet/crate/secure/hydroponics,
 /obj/item/reagent_containers/glass/bottle/ammonia,
@@ -25114,13 +25111,13 @@
 /obj/item/reagent_containers/glass/bottle/ammonia,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mle" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mll" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt,
@@ -25225,7 +25222,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "moH" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -25355,7 +25352,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mtj" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -25430,7 +25427,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -25439,7 +25436,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mvO" = (
 /obj/structure/table/wood,
 /obj/effect/decal/waste{
@@ -25566,7 +25563,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mys" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
@@ -25596,7 +25593,7 @@
 /obj/structure/obstacle/barbedwire/end,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "myM" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
@@ -25604,13 +25601,13 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "myY" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mzc" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -25618,7 +25615,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mzo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -25850,7 +25847,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mBL" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -25872,7 +25869,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mDc" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -26037,7 +26034,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mID" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/f13/inside,
@@ -26071,7 +26068,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mJk" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel{
@@ -26110,7 +26107,7 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mKM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26172,7 +26169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mLt" = (
 /obj/structure/lattice{
 	layer = 3
@@ -26325,7 +26322,7 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mNS" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -26353,7 +26350,7 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mOM" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -26409,7 +26406,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mQL" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -26509,7 +26506,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mSB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26558,7 +26555,7 @@
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "mTL" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science";
@@ -26855,7 +26852,7 @@
 	},
 /obj/effect/spawner/lootdrop/cig_packs,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nbL" = (
 /obj/structure/rack,
 /obj/item/assembly/igniter,
@@ -26900,7 +26897,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ndE" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -26921,7 +26918,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nek" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -26934,7 +26931,7 @@
 /obj/item/mine/shrapnel,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nfw" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26970,7 +26967,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ngD" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd4";
@@ -27117,7 +27114,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "niG" = (
 /obj/structure/chair,
 /mob/living/simple_animal/hostile/enclave/soldier,
@@ -27133,7 +27130,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "niM" = (
 /obj/structure/table/wood/junk,
 /obj/machinery/computer/terminal{
@@ -27183,7 +27180,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "njL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -27193,7 +27190,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nkQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -27310,7 +27307,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nnl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair{
@@ -27345,7 +27342,7 @@
 /obj/structure/spacevine,
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nor" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/reagent_dispensers/barrel/four,
@@ -27356,7 +27353,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "npG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -27404,7 +27401,7 @@
 	},
 /obj/item/melee/onehanded/dragonfire,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nqs" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/barber{
@@ -27422,7 +27419,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nrb" = (
 /obj/structure/table{
 	layer = 2.9
@@ -27453,7 +27450,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nrK" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/spawner/lootdrop/trash,
@@ -27469,7 +27466,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/surgical,
 /obj/effect/spawner/lootdrop/f13/medical/surgical,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nrT" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -27504,7 +27501,7 @@
 /obj/structure/spacevine,
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nsN" = (
 /obj/item/candle{
 	pixel_x = 7;
@@ -27526,7 +27523,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nsZ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/box/ration/menu_ten,
@@ -27534,7 +27531,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nto" = (
 /obj/structure/table{
 	layer = 2.9
@@ -27546,7 +27543,7 @@
 "ntC" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ntD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27630,7 +27627,7 @@
 /area/f13/casino)
 "nwu" = (
 /turf/open/floor/carpet/royalblack,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nwG" = (
 /obj/machinery/power/am_control_unit{
 	anchored = 1;
@@ -27679,7 +27676,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nxY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/hostile/retaliate/poison/snake,
@@ -27759,7 +27756,7 @@
 "nzx" = (
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nzK" = (
 /obj/structure/mecha_wreckage/medigax,
 /turf/open/floor/plating/f13/inside/mountain{
@@ -27917,7 +27914,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nCY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28007,7 +28004,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nEs" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -28026,7 +28023,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nEW" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/r_wall,
@@ -28072,7 +28069,7 @@
 	color = "#343a33"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nGx" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
@@ -28148,7 +28145,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nJe" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -28158,7 +28155,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nJr" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -28167,7 +28164,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nJF" = (
 /obj/machinery/door/poddoor/ert{
 	id = "lock3"
@@ -28239,10 +28236,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
 "nLo" = (
-/turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg1"
-	},
-/area/f13/underground/cave)
+/turf/closed/wall/rust,
+/area/f13/bunker)
 "nLX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/strong,
@@ -28541,7 +28536,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nTq" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -28575,7 +28570,7 @@
 "nUd" = (
 /obj/item/crafting/abraxo,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "nUA" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -29121,7 +29116,7 @@
 	color = "#3c2c21"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oiU" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
@@ -29179,12 +29174,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oko" = (
 /obj/structure/chair/office/dark,
 /obj/item/stack/medical/gauze,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "okr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -29312,7 +29307,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "onF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/floor/plasteel/barber{
@@ -29470,7 +29465,7 @@
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "orO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -29505,7 +29500,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "osu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29552,7 +29547,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oti" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29643,7 +29638,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ovR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -29699,7 +29694,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oxn" = (
 /obj/structure/fluff/railing{
 	dir = 6;
@@ -29771,7 +29766,7 @@
 "ozi" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ozm" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Generator Room";
@@ -29814,7 +29809,7 @@
 "ozL" = (
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ozX" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -30070,7 +30065,7 @@
 	},
 /obj/item/locked_box/weapon/melee/tier4,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oEE" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner,
@@ -30103,7 +30098,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oFl" = (
 /obj/structure/table{
 	layer = 2.9
@@ -30212,13 +30207,13 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oHg" = (
 /obj/structure/chair/f13chair1,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oHk" = (
 /obj/machinery/light/fo13colored/Aqua{
 	brightness = 3;
@@ -30281,7 +30276,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oIw" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -30292,7 +30287,7 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oIN" = (
 /obj/structure/chair{
 	dir = 8
@@ -30327,7 +30322,7 @@
 "oKf" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oKY" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -30442,7 +30437,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oNP" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -30500,7 +30495,7 @@
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oPw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -30515,13 +30510,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oPG" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oPX" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -30536,7 +30531,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oQi" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/ash/snappop_phoenix,
@@ -30684,12 +30679,12 @@
 	dir = 8
 	},
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oTE" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -30745,7 +30740,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oUU" = (
 /obj/structure/table/wood,
 /obj/machinery/light/broken{
@@ -30883,7 +30878,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -30909,11 +30904,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oYI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oYR" = (
 /obj/effect/decal/riverbank{
 	name = "steps";
@@ -30930,7 +30925,7 @@
 	faction = list("tunneler", "jungle")
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "oZg" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -31057,12 +31052,12 @@
 "pcD" = (
 /obj/structure/closet/decay,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pcG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pcH" = (
 /obj/structure/sign/warning{
 	name = "CRUSH HAZARD"
@@ -31130,7 +31125,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "peN" = (
 /obj/structure/easel,
 /turf/open/floor/wood_common,
@@ -31261,7 +31256,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pie" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/mining)
@@ -31347,7 +31342,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pkt" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -31454,7 +31449,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pln" = (
 /obj/item/flag/bos,
 /obj/effect/turf_decal/stripes/red/line,
@@ -31617,7 +31612,7 @@
 /area/f13/bunker/bighornbunker)
 "poH" = (
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "poI" = (
 /obj/structure/fence{
 	dir = 4
@@ -31693,7 +31688,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pqA" = (
 /obj/effect/decal/waste,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -31761,7 +31756,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "prq" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -31884,13 +31879,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "puN" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "puZ" = (
 /mob/living/simple_animal/hostile/enclave/soldier,
 /turf/open/floor/f13{
@@ -31959,7 +31954,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pwr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31987,7 +31982,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pwT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -32021,11 +32016,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "pxJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pxV" = (
 /obj/structure/closet/cabinet{
 	name = "Vault 223 cabinet"
@@ -32137,7 +32131,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pBa" = (
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
@@ -32270,7 +32264,7 @@
 "pEv" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pEF" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/cracked,
@@ -32356,7 +32350,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pGc" = (
 /obj/structure/railing/corner{
 	dir = 1;
@@ -32447,13 +32441,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pIL" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/indestructible/riveted/boss{
-	name = "temple wall"
-	},
-/area/f13/underground/cave)
+/obj/structure/decoration/vent,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "pIM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -32488,7 +32478,7 @@
 	},
 /obj/structure/stone_tile/center/burnt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pJs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32522,11 +32512,11 @@
 "pKa" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pKm" = (
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pKo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32562,13 +32552,13 @@
 "pKC" = (
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pLp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 8
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pLA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32712,7 +32702,7 @@
 "pOW" = (
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pPm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32738,7 +32728,7 @@
 "pPO" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pQh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32765,7 +32755,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pQV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -32806,7 +32796,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pRW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -32914,7 +32904,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pVz" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
@@ -33068,7 +33058,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "pYA" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -33209,7 +33199,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qcA" = (
 /obj/structure/lattice{
 	layer = 3
@@ -33259,7 +33249,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qdl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33318,7 +33308,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qem" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -33338,7 +33328,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qez" = (
 /obj/structure/lattice{
 	layer = 3
@@ -33362,7 +33352,7 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qfg" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -33488,7 +33478,7 @@
 	dir = 8
 	},
 /turf/closed/indestructible/necropolis,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qgQ" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/radiation,
@@ -33556,7 +33546,7 @@
 	pixel_x = -9
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qja" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -33620,7 +33610,7 @@
 "qjR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qjS" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
@@ -33643,7 +33633,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qkT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33832,12 +33822,12 @@
 "qoT" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qpo" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qpp" = (
 /obj/item/gun/ballistic/shotgun/police,
 /obj/structure/guncase/shotgun,
@@ -33890,7 +33880,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qpU" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/hos{
@@ -33908,7 +33898,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qqB" = (
 /obj/effect/decal/cleanable/generic,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -34163,7 +34153,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qxy" = (
 /turf/closed/indestructible/rock,
 /turf/closed/indestructible/rock,
@@ -34206,7 +34196,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qyz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34228,7 +34218,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/corner{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qzu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34289,7 +34279,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qAo" = (
 /obj/machinery/door/airlock,
 /obj/structure/barricade/wooden/crude,
@@ -34317,7 +34307,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qCf" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -34478,7 +34468,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qEQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -34491,7 +34481,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qEZ" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
@@ -34522,7 +34512,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qGk" = (
 /obj/effect/turf_decal/big{
 	dir = 5
@@ -34635,7 +34625,7 @@
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qIp" = (
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -34789,7 +34779,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qLZ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -34820,7 +34810,7 @@
 	},
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qMH" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -35020,7 +35010,7 @@
 "qRQ" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qRZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35086,7 +35076,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qTy" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -35127,7 +35117,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qUH" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -35208,7 +35198,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qXx" = (
 /obj/machinery/shower{
 	dir = 8
@@ -35247,7 +35237,7 @@
 "qYV" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "qZf" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -35480,7 +35470,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rfU" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -35635,7 +35625,7 @@
 	},
 /obj/structure/stone_tile/center/burnt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rhP" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -35683,7 +35673,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "riy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35738,7 +35728,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rks" = (
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/cafeteria,
@@ -35846,7 +35836,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rns" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -35979,7 +35969,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rsf" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36007,7 +35997,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/corner{
 	dir = 4
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rsZ" = (
 /obj/effect/decal/riverbank,
 /obj/effect/turf_decal/weather/dirt{
@@ -36052,7 +36042,7 @@
 "ruo" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ruF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -36108,12 +36098,12 @@
 "rvX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rwb" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rwn" = (
 /turf/open/floor/carpet/blue,
 /area/f13/underground/cave)
@@ -36168,7 +36158,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rwN" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36177,7 +36167,7 @@
 /obj/item/storage/box/emptysandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rxf" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -36329,7 +36319,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rzZ" = (
 /obj/structure/bed{
 	pixel_y = 7
@@ -36448,7 +36438,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rDW" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -36521,7 +36511,7 @@
 "rFj" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rFG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small{
@@ -36583,8 +36573,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "rHH" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/underground/cave)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/f13{
+	icon_state = "greendirtyfull"
+	},
+/area/f13/bunker)
 "rIB" = (
 /obj/machinery/light{
 	dir = 1;
@@ -36658,7 +36651,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rLi" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -36678,7 +36671,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rLr" = (
 /obj/machinery/light{
 	dir = 1;
@@ -36778,7 +36771,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rNw" = (
 /mob/living/simple_animal/hostile/chinese/ranged/assault{
 	desc = "A high ranking chinese soldier.";
@@ -36954,7 +36947,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rPZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -37027,7 +37020,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rRB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -37039,12 +37032,12 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rSd" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rSk" = (
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/offices2nd)
@@ -37063,7 +37056,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rSN" = (
 /obj/structure/rack,
 /obj/item/soap,
@@ -37102,7 +37095,7 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rTE" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -37153,7 +37146,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rVz" = (
 /obj/item/ammo_casing/shotgun/rubbershot,
 /turf/open/floor/carpet/green,
@@ -37201,7 +37194,7 @@
 /obj/effect/decal/cleanable/robot_debris,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rXv" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
@@ -37353,7 +37346,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rZM" = (
 /obj/structure/chair/f13chair1,
 /mob/living/simple_animal/hostile/chinese/ranged/assault{
@@ -37364,7 +37357,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "rZN" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
@@ -37480,7 +37473,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sdc" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -37513,7 +37506,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "seQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -37562,7 +37555,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sfQ" = (
 /obj/structure/table{
 	layer = 2.9
@@ -37598,7 +37591,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/prewar/five,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "shf" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -37676,7 +37669,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/ice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sjg" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -37705,7 +37698,7 @@
 "ski" = (
 /obj/item/kirbyplants,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "skm" = (
 /obj/structure/sign/poster/prewar/poster94{
 	icon_state = "poster69"
@@ -37734,7 +37727,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "skM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/decoration/fire{
@@ -37749,7 +37742,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "skY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/keg/milk,
@@ -37810,10 +37803,8 @@
 	},
 /area/f13/brotherhood/archives)
 "smz" = (
-/turf/closed/indestructible/riveted/boss{
-	name = "temple wall"
-	},
-/area/f13/underground/cave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "smP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -37952,7 +37943,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 8
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sqv" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
@@ -37960,7 +37951,7 @@
 "sqE" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sqY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -38080,7 +38071,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "suD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed{
@@ -38149,7 +38140,7 @@
 /area/f13/building)
 "svA" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "svJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -38215,10 +38206,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "swD" = (
-/turf/closed/indestructible/fakeglass,
-/area/f13/underground/cave)
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/dirt,
+/area/f13/bunker)
 "swE" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -38397,7 +38389,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sAM" = (
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -38471,7 +38463,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sBJ" = (
 /obj/structure/sign/warning{
 	name = "CRUSH HAZARD"
@@ -38504,7 +38496,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sCB" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/enclave/scientist,
@@ -38605,7 +38597,7 @@
 "sFi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sFz" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -38624,7 +38616,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sGl" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38728,7 +38720,7 @@
 	},
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sJv" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -38751,7 +38743,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sKj" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -38817,7 +38809,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sLu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38881,7 +38873,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sMt" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -38997,7 +38989,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sOJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -39012,7 +39004,7 @@
 "sOL" = (
 /obj/structure/timeddoor/threehours,
 /turf/closed/wall/f13/wood,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -39024,7 +39016,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sPh" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -39136,7 +39128,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sSF" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -39305,7 +39297,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "sXQ" = (
 /obj/machinery/button/door{
 	id = "boscheckpoint";
@@ -39483,7 +39475,7 @@
 /obj/structure/bed/old,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tbW" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
@@ -39680,7 +39672,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tgh" = (
 /obj/structure/table,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -39726,7 +39718,7 @@
 /obj/structure/closet/decay,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "thh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -39749,12 +39741,12 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "thT" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tib" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -39821,7 +39813,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -39833,7 +39825,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tku" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -39930,7 +39922,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tnp" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/grille,
@@ -39947,7 +39939,7 @@
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tnI" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -40016,7 +40008,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tpW" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_x = 32
@@ -40053,7 +40045,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "trB" = (
 /obj/effect/turf_decal/big{
 	dir = 8
@@ -40090,7 +40082,7 @@
 "trP" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tsa" = (
 /obj/machinery/door/airlock/security{
 	name = "Barracks";
@@ -40229,12 +40221,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tvx" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tvB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -40295,7 +40287,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "txw" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -40318,7 +40310,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "txV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Overseer Office";
@@ -40424,7 +40416,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/druggie_pill,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tBN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40486,7 +40478,7 @@
 "tDC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tDT" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -40496,7 +40488,7 @@
 "tEa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tEh" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 Cafeteria"
@@ -40526,10 +40518,11 @@
 /turf/open/floor/grass,
 /area/f13/building)
 "tEL" = (
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/area/f13/underground/cave)
+/turf/open/water,
+/area/f13/bunker)
 "tEU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/hostile/gecko,
@@ -40542,7 +40535,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 4
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tFr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -40633,7 +40626,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tHf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40641,7 +40634,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tHs" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 30
@@ -40743,11 +40736,9 @@
 	},
 /area/f13/building)
 "tIm" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
-/area/f13/underground/cave)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "tIq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -40772,7 +40763,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tIE" = (
 /obj/effect/decal/cleanable/glass/plasma,
 /turf/open/floor/carpet/green,
@@ -40780,7 +40771,7 @@
 "tIZ" = (
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tJs" = (
 /obj/structure/table{
 	layer = 2.9
@@ -40803,7 +40794,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tKc" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd6";
@@ -40850,7 +40841,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tKQ" = (
 /obj/structure/noticeboard{
 	name = "display plate";
@@ -40875,7 +40866,7 @@
 /obj/structure/flora/grass/coyote/five,
 /obj/structure/flora/grass/coyote/five,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tLc" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -40897,7 +40888,7 @@
 	randomizer_tag = "Radioshack Radicals"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tMo" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/closet,
@@ -40917,7 +40908,7 @@
 "tMt" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tNe" = (
 /obj/structure/table/wood/bar,
 /obj/item/reagent_containers/glass/rag,
@@ -40977,7 +40968,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tOn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41021,7 +41012,7 @@
 /obj/structure/closet/crate/solarpanel_small,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tPM" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -41173,7 +41164,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tTt" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -41183,7 +41174,7 @@
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tTZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -41247,7 +41238,7 @@
 	},
 /obj/item/clothing/head/helmet/f13/combat/mk2/tribal,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tVy" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -41336,7 +41327,7 @@
 /obj/structure/stone_tile/center/cracked,
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "tXf" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -41428,7 +41419,7 @@
 /obj/item/bedsheet/black,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ual" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -41547,7 +41538,7 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ubZ" = (
 /obj/structure/fans/tiny,
 /turf/closed/indestructible/vaultdoor,
@@ -41744,7 +41735,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ufB" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plating/tunnel,
@@ -41756,7 +41747,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ufL" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -41776,7 +41767,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ugs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41820,7 +41811,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uhT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
@@ -41958,13 +41949,13 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ukC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/coffee,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ukL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -42141,13 +42132,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uqr" = (
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uqs" = (
 /obj/effect/decal/fakelattice{
 	layer = 2.0
@@ -42191,7 +42182,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uqV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
@@ -42225,7 +42216,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "urK" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/eightball,
@@ -42239,7 +42230,7 @@
 	dir = 2
 	},
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "urZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -42292,7 +42283,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "usQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42440,7 +42431,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uxd" = (
 /obj/structure/table,
 /obj/item/crafting/resistor,
@@ -42511,7 +42502,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uzC" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi';
@@ -42529,7 +42520,7 @@
 	},
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uAm" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution{
@@ -42655,7 +42646,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uDP" = (
 /obj/machinery/camera/autoname{
 	dir = 5;
@@ -42900,7 +42891,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uJp" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/white/box,
@@ -43017,7 +43008,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uLV" = (
 /obj/structure/lattice{
 	layer = 3
@@ -43033,7 +43024,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uMb" = (
 /obj/structure/lattice{
 	layer = 3
@@ -43061,7 +43052,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uMV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -43302,7 +43293,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uTF" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/red,
@@ -43375,7 +43366,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uUZ" = (
 /obj/structure/rack{
 	dir = 8;
@@ -43401,7 +43392,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/cig_packs,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "uVF" = (
 /obj/item/clothing/under/f13/vault{
 	desc = "A blue jumpsuit with a yellow vault pattern and the number 223 printed on it.";
@@ -43503,7 +43494,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vak" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -43533,7 +43524,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vaN" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
@@ -43634,13 +43625,13 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vdf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vdm" = (
 /obj/machinery/msgterminal/brotherhood{
 	dir = 8;
@@ -43666,7 +43657,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vdy" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/flora/grass/wasteland{
@@ -43804,7 +43795,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vgR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -43817,7 +43808,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vhj" = (
 /obj/machinery/power/floodlight{
 	pixel_x = 9
@@ -44078,7 +44069,7 @@
 /obj/item/stack/medical/poultice/ten,
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vnh" = (
 /obj/structure/sign/poster/official/build{
 	pixel_y = 32
@@ -44116,7 +44107,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vnq" = (
 /obj/effect/landmark/start/f13/ussgt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44139,7 +44130,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vnP" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/barber{
@@ -44238,7 +44229,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vqW" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -44380,7 +44371,7 @@
 "vub" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vuu" = (
 /obj/machinery/light/fo13colored{
 	dir = 8
@@ -44443,7 +44434,7 @@
 	name = "The Grill Sergeant"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vvh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -44468,17 +44459,17 @@
 /obj/item/stack/medical/poultice/ten,
 /obj/item/flashlight/flashdark,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vvA" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vvB" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vvJ" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -44538,7 +44529,7 @@
 /obj/item/bedsheet/black,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vxF" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -44625,7 +44616,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vzt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44658,7 +44649,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/traitbooks/low,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vAp" = (
 /obj/structure/rack,
 /obj/effect/spawner/bundle/f13/armor/riot,
@@ -44723,7 +44714,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vBw" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -44732,7 +44723,7 @@
 	dir = 4
 	},
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vBy" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -44794,7 +44785,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/corner{
 	dir = 8
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vCH" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -44949,7 +44940,7 @@
 /mob/living/simple_animal/hostile/handy/gutsy,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vHj" = (
 /mob/living/simple_animal/hostile/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -45029,7 +45020,7 @@
 "vJW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vKd" = (
 /obj/structure/rack,
 /obj/item/storage/belt/medical,
@@ -45157,7 +45148,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vNA" = (
 /obj/structure/table/wood/bar,
 /obj/machinery/chem_dispenser/drinks,
@@ -45228,7 +45219,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vOH" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13{
@@ -45298,12 +45289,12 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vRQ" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vRR" = (
 /obj/machinery/light/small{
 	light_color = "#ad1b1b"
@@ -45313,7 +45304,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vRV" = (
 /obj/structure/rack,
 /obj/item/paper/crumpled/bloody{
@@ -45353,7 +45344,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vTH" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -45390,7 +45381,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vUs" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -45416,7 +45407,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vUH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45464,7 +45455,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vWR" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -45524,7 +45515,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vYD" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -45561,7 +45552,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "vZk" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
@@ -45677,7 +45668,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wbO" = (
 /obj/structure/sign/poster/prewar/poster94{
 	icon_state = "poster70";
@@ -45798,14 +45789,14 @@
 /turf/open/indestructible/ground/outside/ruins{
 	color = "#4c4c4c"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wfb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wfd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45912,7 +45903,7 @@
 	},
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "whF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/wood/twenty,
@@ -45933,7 +45924,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wii" = (
 /obj/machinery/hydroponics/constructable{
 	anchored = 0
@@ -45971,7 +45962,7 @@
 /obj/item/clothing/head/helmet/f13/combat/tribal,
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/tribal,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wjE" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
@@ -46071,7 +46062,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wlk" = (
 /obj/structure/lattice{
 	density = 1
@@ -46112,7 +46103,7 @@
 "wlW" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wmh" = (
 /obj/effect/turf_decal/big{
 	dir = 8
@@ -46130,7 +46121,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wmI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -46189,7 +46180,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wow" = (
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -46342,7 +46333,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_bigboss,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wto" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/head/f13/gambler,
@@ -46353,7 +46344,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wtu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/light/small{
@@ -46361,7 +46352,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wtv" = (
 /obj/structure/rack,
 /turf/open/floor/mineral/plastitanium,
@@ -46418,7 +46409,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wuL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -46460,7 +46451,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wvF" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -46481,7 +46472,7 @@
 /obj/item/clothing/suit/hooded/robes/grey,
 /obj/item/clothing/suit/hooded/cloak/goliath,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wvL" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -46517,7 +46508,7 @@
 "wwE" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wwT" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -46544,13 +46535,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wxi" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
 /turf/closed/wall/rust,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wxN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46569,7 +46560,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wxT" = (
 /turf/open/floor/wood_common,
 /area/f13/underground/cave)
@@ -46666,7 +46657,7 @@
 	},
 /obj/item/drone_shell/ancient,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wzG" = (
 /obj/machinery/light{
 	dir = 8;
@@ -46687,7 +46678,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wzX" = (
 /obj/structure/sink{
 	dir = 8
@@ -46706,7 +46697,7 @@
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /obj/item/clothing/glasses/f13/tribaleyepatch,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wAw" = (
 /obj/structure/rack,
 /obj/item/soap,
@@ -46845,7 +46836,7 @@
 "wDG" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wDR" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -46870,7 +46861,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wEt" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13{
@@ -46981,7 +46972,7 @@
 "wIR" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wIY" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -46997,7 +46988,7 @@
 	name = "Military Stockpile Shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wJk" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -47038,7 +47029,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wJR" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/fo13colored/Aqua{
@@ -47075,7 +47066,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/water,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wLb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -47095,7 +47086,7 @@
 	termtag = "Public"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wMk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47182,7 +47173,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wOb" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -47268,7 +47259,7 @@
 "wRp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wRq" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/nest/supermutant,
@@ -47296,7 +47287,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wSm" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
@@ -47306,7 +47297,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wSr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47352,7 +47343,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wTk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47409,7 +47400,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wUc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -47436,7 +47427,7 @@
 "wUV" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wVc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -47498,7 +47489,7 @@
 	color = "#3c2c21"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wWg" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -47531,7 +47522,7 @@
 "wWr" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wWE" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -47568,7 +47559,7 @@
 "wXe" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wXo" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
@@ -47671,7 +47662,7 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "wYV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -47730,7 +47721,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xbi" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/rd{
@@ -47785,7 +47776,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xbU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47928,7 +47919,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
@@ -47944,7 +47935,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/bundle/f13/armor/combat,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xhj" = (
 /obj/machinery/workbench,
 /obj/structure/sink/kitchen{
@@ -47983,7 +47974,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xjq" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
@@ -48023,7 +48014,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xkD" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel,
@@ -48031,7 +48022,7 @@
 "xkL" = (
 /obj/item/clothing/suit/armor/heavy/tribal/westernwayfarer,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xlo" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
@@ -48064,7 +48055,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xlW" = (
 /obj/structure/table{
 	layer = 2.9
@@ -48102,7 +48093,7 @@
 	name = "ancient turret"
 	},
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xmP" = (
 /obj/item/paper_bin,
 /obj/structure/table{
@@ -48164,7 +48155,7 @@
 "xpb" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48173,13 +48164,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xpl" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xpv" = (
 /obj/structure/sign/basic{
 	color = "#FF0000";
@@ -48308,14 +48299,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xtA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xtH" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -48385,7 +48376,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xvb" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -48481,7 +48472,7 @@
 	pixel_y = -12
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xwW" = (
 /mob/living/simple_animal/hostile/enclave,
 /turf/open/floor/f13{
@@ -48510,7 +48501,7 @@
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xxD" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/f13/wood,
@@ -48556,7 +48547,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xzo" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -48638,7 +48629,7 @@
 "xAk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xAs" = (
 /obj/structure/chair/right,
 /obj/item/radio/intercom{
@@ -48686,7 +48677,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xCb" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -48749,7 +48740,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xDz" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -48776,7 +48767,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xEM" = (
 /mob/living/simple_animal/hostile/gelcube{
 	faction = list("the tungsten cube","supermutant")
@@ -48828,7 +48819,7 @@
 	},
 /obj/structure/nest/tunneler,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation{
@@ -48847,7 +48838,7 @@
 "xGQ" = (
 /obj/structure/glowshroom,
 /turf/open/floor/plasteel/cult,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xHv" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -48855,7 +48846,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xHx" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -48888,7 +48879,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xIe" = (
 /obj/structure/chair/comfy/plywood,
 /turf/open/indestructible/ground/outside/desert,
@@ -48901,7 +48892,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xIN" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -48996,7 +48987,7 @@
 	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xKD" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
@@ -49017,7 +49008,7 @@
 	pixel_y = -13
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xLh" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/carpet/blue,
@@ -49039,7 +49030,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xLF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49116,7 +49107,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xOi" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -49137,7 +49128,7 @@
 "xOv" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/ice,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xOy" = (
 /obj/structure/debris/v4,
 /turf/open/floor/circuit/red/anim,
@@ -49164,7 +49155,7 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xPE" = (
 /obj/structure/table{
 	layer = 2.9
@@ -49242,7 +49233,7 @@
 "xQu" = (
 /obj/structure/bed/old,
 /turf/open/floor/carpet/royalblack,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xQy" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -49292,7 +49283,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xSi" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -49341,7 +49332,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -49422,7 +49413,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "xWe" = (
 /obj/structure/rack,
 /obj/item/pda/engineering{
@@ -49554,7 +49545,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "yaF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -49620,7 +49611,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ycw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -49632,7 +49623,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "ycP" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
@@ -49687,7 +49678,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 4
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "yeA" = (
 /obj/machinery/light/small{
 	pixel_x = -16
@@ -49848,7 +49839,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
-/area/f13/underground/cave)
+/area/f13/bunker)
 "yhW" = (
 /obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -69479,15 +69470,15 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 whv
 whv
 whv
@@ -69717,13 +69708,13 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 whv
 whv
 whv
@@ -69736,7 +69727,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 cFY
 cFY
@@ -69744,7 +69735,7 @@ sFi
 rRA
 cFY
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -69974,13 +69965,13 @@ whv
 whv
 whv
 whv
-thd
+nLo
 eIa
 lpq
 ycN
 lpq
 awL
-thd
+nLo
 whv
 whv
 whv
@@ -69993,15 +69984,15 @@ whv
 whv
 whv
 whv
-thd
+nLo
 cLK
 miw
 lpq
-thd
+nLo
 lpq
 mfF
 cLK
-thd
+nLo
 whv
 whv
 whv
@@ -70231,34 +70222,34 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 lpq
 lpq
 lpq
 lpq
-thd
+nLo
 whv
 whv
 whv
 whv
 whv
-thd
-thd
-thd
+nLo
+nLo
+nLo
 whv
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 ixP
-thd
+nLo
 vcO
-thd
-thd
-thd
+nLo
+nLo
+nLo
 whv
 whv
 whv
@@ -70488,25 +70479,25 @@ whv
 whv
 whv
 whv
-thd
+nLo
 few
 lpq
 kqe
 lpq
 fDV
-thd
+nLo
 whv
 whv
 whv
 whv
 whv
-thd
+nLo
 xSX
-thd
+nLo
 whv
-thd
+nLo
 jDZ
-thd
+nLo
 whv
 whv
 wxi
@@ -70514,7 +70505,7 @@ cFY
 lid
 lzX
 cFY
-thd
+nLo
 whv
 whv
 whv
@@ -70745,28 +70736,28 @@ whv
 whv
 whv
 whv
-thd
+nLo
 mah
 lpq
 nsZ
 lpq
 mSr
-thd
+nLo
 whv
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 ixP
-thd
-thd
-thd
+nLo
+nLo
+nLo
 ixP
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
 cFY
 qkM
 ann
@@ -71002,15 +70993,15 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lnG
 lpq
 eQl
 lpq
 lFa
-thd
+nLo
 whv
-thd
+nLo
 lpq
 kwX
 ixP
@@ -71259,33 +71250,33 @@ whv
 whv
 whv
 whv
-thd
+nLo
 pwo
 lpq
 lpq
 lpq
 vnO
-thd
+nLo
 whv
-thd
+nLo
 lpq
-thd
-thd
+nLo
+nLo
 sFi
 ixP
-thd
+nLo
 vcO
-thd
+nLo
 vcO
-thd
+nLo
 sFi
-thd
+nLo
 wxi
 xuZ
 cFY
 lpq
 jTl
-thd
+nLo
 whv
 whv
 whv
@@ -71516,33 +71507,33 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
+nLo
+nLo
+nLo
 ixP
-thd
-thd
-thd
+nLo
+nLo
+nLo
 whv
 wxi
 wSX
-thd
+nLo
 whv
-thd
+nLo
 thq
-thd
+nLo
 lpq
-thd
+nLo
 jvG
-thd
+nLo
 whv
 whv
-thd
+nLo
 mvz
 cFY
 jKj
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -71775,34 +71766,34 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
-thd
-thd
-thd
+nLo
+nLo
+nLo
 cFY
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 wxi
-thd
+nLo
 ixP
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 whv
 bpQ
 pPM
@@ -72032,23 +72023,23 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
-thd
+nLo
 lpq
-thd
-thd
+nLo
+nLo
 whv
 whv
-thd
+nLo
 cFY
-thd
-thd
-thd
+nLo
+nLo
+nLo
 jTl
 lpq
 lpq
@@ -72059,7 +72050,7 @@ lpq
 kwX
 lpq
 gjZ
-thd
+nLo
 whv
 bpQ
 pPM
@@ -72288,17 +72279,17 @@ whv
 whv
 whv
 whv
-thd
-thd
+nLo
+nLo
 ixP
-thd
-thd
+nLo
+nLo
 wxi
-thd
-thd
+nLo
+nLo
 ixP
-thd
-thd
+nLo
+nLo
 whv
 whv
 wxi
@@ -72316,7 +72307,7 @@ vnn
 ipq
 wSX
 lpq
-thd
+nLo
 whv
 bpQ
 pPM
@@ -72545,7 +72536,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 bYT
 lpq
 lpq
@@ -72560,8 +72551,8 @@ whv
 whv
 wxi
 cFY
-thd
-thd
+nLo
+nLo
 sFi
 lpq
 lpq
@@ -72573,7 +72564,7 @@ jpB
 csk
 lpq
 lpq
-thd
+nLo
 whv
 bpQ
 pPM
@@ -72802,7 +72793,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 cFY
 rRA
 rRA
@@ -72815,11 +72806,11 @@ lpq
 wxi
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
-thd
+nLo
 kZj
 lpq
 cFY
@@ -72830,7 +72821,7 @@ xiU
 tIw
 lpq
 myj
-thd
+nLo
 whv
 bpQ
 pPM
@@ -73059,7 +73050,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 dvN
 vBs
@@ -73070,9 +73061,9 @@ hBO
 aPd
 lpq
 wxi
-thd
-thd
-thd
+nLo
+nLo
+nLo
 lpq
 sFi
 whv
@@ -73087,7 +73078,7 @@ cFY
 dyh
 xuZ
 lFE
-thd
+nLo
 whv
 bpQ
 pPM
@@ -73316,7 +73307,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 jTl
 nEn
@@ -73344,7 +73335,7 @@ oHg
 csk
 cFY
 oIr
-thd
+nLo
 whv
 bpQ
 pPM
@@ -73573,7 +73564,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 ijf
 xHv
 fXK
@@ -73583,14 +73574,14 @@ xHv
 dmP
 dVu
 lpq
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 sFi
 whv
-thd
+nLo
 cFY
 lpq
 cFY
@@ -73601,7 +73592,7 @@ rZM
 ipq
 cFY
 lpq
-thd
+nLo
 whv
 bpQ
 pPM
@@ -73847,7 +73838,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 lpq
 cFY
@@ -73858,7 +73849,7 @@ oHg
 ipq
 cFY
 lpq
-thd
+nLo
 whv
 bpQ
 pPM
@@ -74087,7 +74078,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 nEn
 jTl
@@ -74097,14 +74088,14 @@ nEn
 nEn
 nEn
 cFY
-thd
+nLo
 whv
 whv
 whv
 whv
 whv
 whv
-thd
+nLo
 jTl
 lpq
 lpq
@@ -74115,7 +74106,7 @@ lpq
 ikW
 cFY
 ipq
-thd
+nLo
 whv
 bpQ
 pPM
@@ -74344,7 +74335,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 awz
 niJ
@@ -74354,26 +74345,26 @@ xHv
 dSL
 dVu
 lpq
-thd
+nLo
 whv
 whv
 whv
 whv
 whv
 whv
-thd
-thd
-thd
+nLo
+nLo
+nLo
 wxi
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
 wxi
 ixP
-thd
-thd
-thd
+nLo
+nLo
+nLo
 bpQ
 pPM
 lju
@@ -74601,7 +74592,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 cFY
 lpq
@@ -74611,14 +74602,14 @@ lpq
 lpq
 lpq
 lpq
-thd
+nLo
 whv
 whv
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 cDj
 eEC
 lRk
@@ -74630,7 +74621,7 @@ lnQ
 lpq
 esH
 lpq
-thd
+nLo
 bpQ
 pPM
 lju
@@ -74858,23 +74849,23 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 ixP
-thd
+nLo
 wxi
-thd
-thd
-thd
+nLo
+nLo
+nLo
 whv
 whv
-thd
+nLo
 kwX
 lpq
-rFN
+rHH
 ixP
 lpq
 cFY
@@ -74887,7 +74878,7 @@ lpq
 cFY
 cFY
 lpq
-thd
+nLo
 bpQ
 pPM
 cXJ
@@ -75113,26 +75104,26 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 sFi
 lpq
-thd
+nLo
 whv
 whv
 whv
 whv
 whv
 whv
-thd
+nLo
 lpq
-thd
-thd
-thd
+nLo
+nLo
+nLo
 rnl
 cFY
 lpq
@@ -75370,7 +75361,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 tOg
 bpR
 ixP
@@ -75383,13 +75374,13 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
+nLo
+nLo
+nLo
 lpq
-thd
+nLo
 whv
-thd
+nLo
 kbf
 ann
 mvN
@@ -75627,38 +75618,38 @@ whv
 whv
 whv
 whv
-thd
+nLo
 sFi
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 sFi
-thd
+nLo
 whv
 whv
 whv
 whv
-thd
+nLo
 eOO
 rip
 lpq
-thd
+nLo
 whv
-thd
-thd
+nLo
+nLo
 wxi
 wxi
-thd
-thd
-thd
+nLo
+nLo
+nLo
 wxi
 lpq
 lpq
 cFY
 fmx
-thd
+nLo
 bpQ
 pPM
 cXJ
@@ -75892,16 +75883,16 @@ whv
 whv
 whv
 whv
-whv
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 jTl
 jTl
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -75912,10 +75903,10 @@ whv
 whv
 wxi
 wxi
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
 bpQ
 pPM
 pPM
@@ -76143,22 +76134,22 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
 knN
-thd
+nLo
 uTB
 kwX
 jZr
-thd
-thd
+nLo
+nLo
 jTl
 jTl
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -76400,22 +76391,22 @@ whv
 whv
 whv
 whv
-thd
+nLo
 rRB
 uTB
 dqH
-thd
+nLo
 whv
-thd
+nLo
 jsr
 cys
 lpq
-thd
-thd
+nLo
+nLo
 dVu
 dVu
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -76657,22 +76648,22 @@ whv
 whv
 whv
 whv
-thd
+nLo
 kGV
 jsr
 rVm
-thd
+nLo
 knN
-thd
+nLo
 nsS
 bTp
 kaS
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -76914,22 +76905,22 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 mbn
 cDX
-thd
+nLo
 dER
 sFi
 lpq
 seK
 pwR
-thd
+nLo
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -77171,7 +77162,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 oHg
 uML
 wSX
@@ -77181,12 +77172,12 @@ geM
 lhr
 cFY
 ftb
-thd
+nLo
 whv
 whv
-thd
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -77428,7 +77419,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 lpq
 cFY
 ghO
@@ -77437,13 +77428,13 @@ coy
 bJw
 bJw
 sFi
+nLo
+nLo
 thd
 thd
-thd
-thd
-thd
+nLo
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -77685,10 +77676,10 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
 sFi
 lpq
 whY
@@ -77700,7 +77691,7 @@ rFN
 rFN
 kwX
 lpq
-thd
+nLo
 whv
 whv
 whv
@@ -77942,7 +77933,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 atm
 jyu
 nsS
@@ -77952,12 +77943,12 @@ cFY
 seK
 ftb
 oUO
+nLo
 thd
 thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
 whv
 whv
 whv
@@ -78199,7 +78190,7 @@ whv
 whv
 whv
 whv
-thd
+nLo
 qxm
 lpq
 seK
@@ -78209,7 +78200,7 @@ ftb
 uTB
 lpq
 oUO
-thd
+nLo
 whv
 whv
 whv
@@ -78456,17 +78447,17 @@ whv
 whv
 whv
 whv
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
-thd
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
+nLo
 whv
 whv
 whv
@@ -79408,16 +79399,16 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -79665,16 +79656,16 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 cyC
-cka
-wWG
+ijt
+ctX
 fZj
-cka
-wWG
+ijt
+ctX
 dJY
-cka
-wWG
+ijt
+ctX
 whv
 whv
 whv
@@ -79922,16 +79913,16 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 fnW
 gYU
-wWG
+ctX
 man
 gYU
-wWG
+ctX
 ajn
 gYU
-wWG
+ctX
 whv
 whv
 whv
@@ -80179,19 +80170,19 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 aIj
-cka
-wWG
+ijt
+ctX
 wYS
-cka
-wWG
+ijt
+ctX
 qpo
-cka
-wWG
-wWG
-wWG
-wWG
+ijt
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -80436,19 +80427,19 @@ whv
 whv
 whv
 whv
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
+ctX
 hOA
 tLP
-wWG
+ctX
 whv
 whv
 whv
@@ -80658,24 +80649,24 @@ whv
 whv
 whv
 whv
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
 whv
@@ -80693,19 +80684,19 @@ whv
 whv
 whv
 whv
-aBC
+pIL
 tvx
 kzv
 xBU
-cka
+ijt
 kzv
 csF
 xtj
-cka
+ijt
 dCV
 wfb
 oIB
-wWG
+ctX
 whv
 whv
 whv
@@ -80915,24 +80906,24 @@ whv
 whv
 whv
 whv
-smz
-smz
+jKo
+jKo
 lRK
 nqo
 lRK
-smz
-smz
+jKo
+jKo
 nwu
 xQu
 nwu
-smz
+jKo
 lRK
 poH
 poH
 lRK
-smz
-smz
-smz
+jKo
+jKo
+jKo
 whv
 whv
 whv
@@ -80950,19 +80941,19 @@ whv
 whv
 whv
 whv
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
-wWG
+ctX
+ctX
 lwe
-wWG
+ctX
 pKa
 lSv
-wWG
+ctX
 whv
 whv
 whv
@@ -81172,24 +81163,24 @@ whv
 whv
 whv
 whv
-smz
-smz
+jKo
+jKo
 qoT
 qoT
 qoT
-smz
-smz
+jKo
+jKo
 nwu
 nwu
 nwu
-smz
+jKo
 qoT
 qoT
 qoT
 qoT
-smz
-smz
-smz
+jKo
+jKo
+jKo
 whv
 whv
 whv
@@ -81207,19 +81198,19 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 gMH
-cka
-wWG
+ijt
+ctX
 cyL
-cka
-wWG
+ijt
+ctX
 aqu
-cka
-wWG
+ijt
+ctX
 ukr
 xAk
-wWG
+ctX
 whv
 whv
 whv
@@ -81429,24 +81420,24 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 poH
 poH
 eaC
 urQ
-smz
+jKo
 nwu
 nwu
 nwu
-smz
+jKo
 nwu
 nwu
 nwu
 nwu
 qoT
 wjt
-smz
+jKo
 whv
 whv
 whv
@@ -81464,19 +81455,19 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 als
 gYU
-wWG
+ctX
 man
 gYU
-wWG
+ctX
 bCR
 gYU
-wWG
+ctX
 svA
 ozL
-wWG
+ctX
 whv
 whv
 whv
@@ -81686,24 +81677,24 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
 tIZ
 bRa
-vMz
-ptZ
-smz
+tEL
+hii
+jKo
 poH
 poH
 iyP
-smz
+jKo
 nwu
 nwu
 nwu
 nwu
 qoT
 eZU
-smz
+jKo
 whv
 whv
 whv
@@ -81721,24 +81712,24 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 sOH
-cka
-wWG
+ijt
+ctX
 tPI
-cka
-wWG
+ijt
+ctX
 mlc
-cka
-wWG
+ijt
+ctX
 wEr
 wEr
-wWG
-wWG
-aBC
-wWG
-wWG
-wWG
+ctX
+ctX
+pIL
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -81943,24 +81934,24 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
 tIZ
 bRa
 gSv
 wbK
-smz
+jKo
 xmO
 poH
 xmO
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 whv
 whv
 whv
@@ -81978,16 +81969,16 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 dIW
 xAk
 gwy
@@ -81995,7 +81986,7 @@ eyb
 xzn
 gZi
 kdr
-wWG
+ctX
 whv
 whv
 whv
@@ -82200,24 +82191,24 @@ whv
 whv
 whv
 whv
-smz
+jKo
 gfI
-smz
+jKo
 tIZ
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
 poH
 xGQ
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -82235,7 +82226,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 fgN
 vUd
 cof
@@ -82252,9 +82243,9 @@ btQ
 fAx
 suz
 meN
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -82457,7 +82448,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
 poH
 poH
@@ -82474,7 +82465,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -82492,7 +82483,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 wvy
 tGZ
 nqU
@@ -82511,7 +82502,7 @@ bJE
 tvp
 aVC
 lBc
-wWG
+ctX
 whv
 whv
 whv
@@ -82714,14 +82705,14 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 tIZ
 poH
-smz
+jKo
 dsN
 poH
-smz
+jKo
 poH
 poH
 poH
@@ -82731,7 +82722,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -82749,7 +82740,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 bPL
 aMb
 mCN
@@ -82758,17 +82749,17 @@ hOY
 eNk
 mCN
 vRR
-wWG
+ctX
 uAc
 uAc
-wWG
+ctX
 bqX
 ukC
 bqX
-wWG
-wWG
+ctX
+ctX
 eQN
-wWG
+ctX
 whv
 whv
 whv
@@ -82949,8 +82940,8 @@ whv
 whv
 whv
 whv
-smz
-smz
+jKo
+jKo
 gfI
 whv
 whv
@@ -82970,8 +82961,8 @@ whv
 whv
 whv
 whv
-smz
-smz
+jKo
+jKo
 poH
 tIZ
 dsN
@@ -82988,7 +82979,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -83006,7 +82997,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 ahi
 tGZ
 tqQ
@@ -83015,7 +83006,7 @@ tqQ
 sJX
 tqQ
 sJX
-wWG
+ctX
 fGk
 fGk
 ltS
@@ -83023,9 +83014,9 @@ kLl
 iud
 vub
 gAM
-wWG
+ctX
 ovK
-wWG
+ctX
 whv
 whv
 whv
@@ -83206,7 +83197,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 dpj
 gfI
 whv
@@ -83227,7 +83218,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 xmO
 poH
 poH
@@ -83245,7 +83236,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -83263,7 +83254,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 tqQ
 wtp
 jOv
@@ -83272,7 +83263,7 @@ rSI
 cGz
 mJh
 tqQ
-wWG
+ctX
 uVu
 kIM
 txT
@@ -83282,7 +83273,7 @@ cab
 btQ
 aVC
 lBc
-wWG
+ctX
 whv
 whv
 whv
@@ -83469,24 +83460,24 @@ gfI
 whv
 whv
 whv
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 gfI
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
 whv
 whv
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
 poH
 kyF
@@ -83494,15 +83485,15 @@ qpS
 dsN
 poH
 poH
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 poH
-smz
+jKo
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -83520,16 +83511,16 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 svA
 xxh
 mle
@@ -83537,11 +83528,11 @@ dIN
 iSW
 dIN
 mle
-wWG
-wWG
-wWG
-chr
-chr
+ctX
+ctX
+ctX
+sME
+sME
 whv
 whv
 whv
@@ -83720,15 +83711,13 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
-smz
-smz
-smz
-smz
-smz
-poH
-poH
+jKo
+jKo
+jKo
+jKo
+jKo
 poH
 poH
 poH
@@ -83736,10 +83725,12 @@ poH
 poH
 poH
 poH
-smz
-smz
-smz
-smz
+poH
+poH
+jKo
+jKo
+jKo
+jKo
 whv
 whv
 gfI
@@ -83759,7 +83750,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -83777,28 +83768,28 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-hii
-hii
-hii
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+uRs
+uRs
+uRs
+ctX
+ctX
 isR
 wJh
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 aME
 tge
-pxJ
-chr
+bcL
+sME
 whv
 whv
 whv
@@ -83974,29 +83965,29 @@ whv
 whv
 whv
 whv
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 peA
-smz
+jKo
 dsN
 tIZ
 xmO
 gfI
 gfI
 gfI
-smz
+jKo
 gfI
-smz
+jKo
 poH
-smz
-smz
-poH
-poH
+jKo
+jKo
 poH
 poH
-smz
+poH
+poH
+jKo
 whv
 whv
 gfI
@@ -84016,7 +84007,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -84035,7 +84026,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 oko
 gjo
 xAk
@@ -84046,16 +84037,16 @@ naY
 wJh
 lWR
 gAx
-wWG
+ctX
 whv
 whv
 whv
 whv
-aBC
+pIL
 pRC
 erq
 sAC
-chr
+sME
 whv
 whv
 whv
@@ -84231,7 +84222,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
 poH
 nsC
@@ -84248,15 +84239,15 @@ poH
 tIZ
 poH
 xGQ
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 poH
-smz
+jKo
 whv
 whv
-smz
+jKo
 aAs
 poH
 poH
@@ -84273,7 +84264,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -84292,7 +84283,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 svA
 uzA
 svA
@@ -84303,16 +84294,16 @@ qzF
 wJh
 wRT
 gOx
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 nrE
-chr
+sME
 whv
 whv
 whv
@@ -84488,29 +84479,29 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 tIZ
 poH
 xmO
 gfI
-smz
+jKo
 poH
-smz
+jKo
 gfI
-smz
-smz
+jKo
+jKo
 poH
-smz
+jKo
 rhL
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 gfI
@@ -84530,7 +84521,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -84549,27 +84540,27 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 khO
 oYx
-wWG
-wWG
-wWG
-hii
-wWG
-wWG
+ctX
+ctX
+ctX
+uRs
+ctX
+ctX
 wJh
 isR
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 xbP
-chr
+sME
 whv
 whv
 whv
@@ -84745,16 +84736,16 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
-smz
+jKo
 maW
 maW
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
 aAs
 poH
 dsN
@@ -84763,23 +84754,23 @@ qyw
 poH
 poH
 gfI
-smz
-smz
+jKo
+jKo
 poH
-smz
-smz
+jKo
+jKo
 whv
 whv
-smz
+jKo
 poH
 tIZ
 poH
-smz
-smz
+jKo
+jKo
 poH
 tIZ
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
@@ -84787,7 +84778,7 @@ poH
 poH
 xmO
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -84806,27 +84797,27 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 uzA
 uLW
-wWG
+ctX
 btQ
 btQ
 btQ
 lVG
-wWG
+ctX
 kIM
 svA
-wWG
+ctX
 kmF
 hLi
 rPO
 djl
 jBd
 agL
-wWG
-tEL
-chr
+ctX
+yfO
+sME
 whv
 whv
 whv
@@ -85002,18 +84993,18 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
-smz
+jKo
 dsN
 tIZ
 tIZ
 tIZ
 dsN
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 poH
 dsN
 dsN
@@ -85023,28 +85014,28 @@ poH
 poH
 tIZ
 poH
-smz
-smz
+jKo
+jKo
 whv
 whv
-smz
+jKo
 tIZ
 tIZ
 tIZ
 gfI
-smz
+jKo
 poH
 poH
 poH
-smz
+jKo
 poH
 poH
 poH
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -85063,15 +85054,15 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 ycv
 xAk
-wWG
+ctX
 yay
 thT
 thT
 btQ
-wWG
+ctX
 cRj
 swz
 eGM
@@ -85081,9 +85072,9 @@ ajy
 pAS
 aPE
 tEa
-wWG
+ctX
 qdf
-chr
+sME
 whv
 whv
 whv
@@ -85259,31 +85250,31 @@ whv
 whv
 whv
 whv
-smz
+jKo
 tIZ
 gfI
 tIZ
-smz
-smz
-smz
+jKo
+jKo
+jKo
 tIZ
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 poH
-smz
-smz
+jKo
+jKo
 gfI
-smz
+jKo
 poH
 xGQ
-smz
+jKo
 gfI
-smz
+jKo
 gfI
 tIZ
 poH
@@ -85301,7 +85292,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -85320,7 +85311,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 uYL
 vNv
 bXR
@@ -85328,19 +85319,19 @@ yay
 fAx
 fAx
 fAx
-wWG
+ctX
 ljK
 irt
-wWG
+ctX
 lwU
 asx
 ajy
 dhU
 ovK
 vJW
-wWG
+ctX
 gtn
-chr
+sME
 whv
 whv
 whv
@@ -85516,11 +85507,11 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 tIZ
 tIZ
-smz
+jKo
 gfI
 poH
 tIZ
@@ -85529,12 +85520,12 @@ poH
 xGQ
 poH
 fnC
-smz
+jKo
 tIZ
 tIZ
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
 poH
 poH
@@ -85558,46 +85549,46 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 xAk
 sXP
-wWG
+ctX
 vvA
 btQ
 fAx
 btQ
-wWG
+ctX
 eBM
 xDs
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
 tTp
-wWG
-wWG
+ctX
+ctX
 tTp
-chr
+sME
 whv
 whv
 whv
@@ -85773,29 +85764,29 @@ whv
 whv
 whv
 whv
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
 gfI
 qiG
-smz
-smz
-smz
-fww
+jKo
+jKo
+jKo
+pxJ
 gfI
 poH
-smz
+jKo
 gfI
 poH
 poH
 poH
-smz
+jKo
 poH
 aAs
 poH
-smz
+jKo
 gfI
 gfI
 gfI
@@ -85807,54 +85798,54 @@ tIZ
 qpS
 poH
 dLC
-smz
+jKo
 poH
-smz
+jKo
 poH
 poH
 aAs
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-rHH
-rHH
-rHH
-rHH
-rHH
-rHH
-wWG
+ctX
+eWm
+eWm
+eWm
+eWm
+eWm
+eWm
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 wDG
 qSX
-wWG
+ctX
 vvA
 xzn
 qLx
 kfb
-wWG
+ctX
 wDG
 okc
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 isq
-kgs
+kce
 dcj
-kgs
-chr
+kce
+sME
 whv
 whv
 whv
@@ -86033,11 +86024,11 @@ whv
 whv
 whv
 whv
-smz
-smz
-smz
+jKo
+jKo
+jKo
 tIZ
-smz
+jKo
 xGr
 pld
 tIZ
@@ -86046,9 +86037,9 @@ tIZ
 gfI
 gfI
 poH
-smz
+jKo
 tIZ
-smz
+jKo
 tIZ
 poH
 tIZ
@@ -86072,46 +86063,46 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-rHH
-rHH
-ijt
-ijt
-ijt
-rHH
-wWG
+ctX
+eWm
+eWm
+qRE
+qRE
+qRE
+eWm
+ctX
 whv
 whv
 whv
 whv
 whv
-aBC
+pIL
 mLs
 lHb
-wWG
+ctX
 vvA
 cab
 btQ
 btQ
-wWG
+ctX
 gdr
 khO
-wWG
+ctX
 whv
 whv
 whv
-chr
-tEL
-chr
-chr
-chr
-chr
+sME
+yfO
+sME
+sME
+sME
+sME
 whv
 whv
 whv
@@ -86290,14 +86281,14 @@ whv
 whv
 whv
 whv
-smz
+jKo
 oEz
 gfI
 poH
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 gfI
 poH
 poH
@@ -86309,10 +86300,10 @@ poH
 poH
 poH
 tIZ
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 tIZ
 poH
 dsN
@@ -86329,26 +86320,26 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-rHH
-rHH
-ijt
+ctX
+eWm
+eWm
+qRE
 hHb
-ijt
-rHH
-wWG
+qRE
+eWm
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 xAk
 eRb
 bXR
@@ -86356,16 +86347,16 @@ cab
 btQ
 vvf
 btQ
-wWG
+ctX
 bTt
 xAk
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 niF
-chr
+sME
 whv
 whv
 whv
@@ -86547,9 +86538,9 @@ whv
 whv
 whv
 whv
-smz
+jKo
 oNL
-smz
+jKo
 tIZ
 tIZ
 xPu
@@ -86558,15 +86549,15 @@ gfI
 tIZ
 poH
 tIZ
-smz
+jKo
 poH
-smz
+jKo
 poH
 gfI
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 gfI
@@ -86578,28 +86569,28 @@ gfI
 poH
 dUM
 dsN
-smz
+jKo
 poH
 poH
 poH
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-rHH
-rHH
-ijt
-ijt
-ijt
-rHH
-wWG
+ctX
+eWm
+eWm
+qRE
+qRE
+qRE
+eWm
+ctX
 whv
 whv
 whv
@@ -86608,21 +86599,21 @@ whv
 jpA
 dzf
 mNP
-wWG
+ctX
 btQ
 qqp
 nrR
 btQ
-wWG
+ctX
 ufE
 aqV
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 jev
-chr
+sME
 whv
 whv
 whv
@@ -86804,38 +86795,38 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 pld
 poH
-smz
+jKo
 gfI
 tIZ
 gfI
-smz
-smz
+jKo
+jKo
 gfI
-smz
+jKo
 tIZ
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
-smz
+jKo
 tIZ
 tIZ
 tIZ
-smz
-smz
+jKo
+jKo
 poH
 poH
 gfI
-smz
+jKo
 poH
 poH
 poH
@@ -86843,20 +86834,20 @@ poH
 poH
 xmO
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-rHH
-rHH
-swD
+ctX
+eWm
+eWm
+eRF
 dhg
-swD
-rHH
-wWG
+eRF
+eWm
+ctX
 whv
 whv
 whv
@@ -86865,21 +86856,21 @@ whv
 jpA
 dlk
 dIW
-wWG
+ctX
 mOL
 btQ
 btQ
 cab
-wWG
+ctX
 rvX
 uhM
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 nnj
-chr
+sME
 whv
 whv
 whv
@@ -87059,31 +87050,31 @@ ghS
 whv
 ghS
 ghS
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 sGg
-pIL
+tyi
 poH
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
-smz
+jKo
 poH
 poH
 tIZ
@@ -87100,20 +87091,20 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 loe
 tFd
 tFd
 yex
 tFd
 rsS
-wWG
+ctX
 whv
 whv
 whv
@@ -87122,27 +87113,27 @@ whv
 jpA
 mNP
 ddb
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 xSa
 dMK
-wWG
+ctX
 whv
 whv
 whv
-chr
-pxJ
-chr
-chr
-chr
-chr
-chr
-chr
-chr
+sME
+bcL
+sME
+sME
+sME
+sME
+sME
+sME
+sME
 whv
 whv
 whv
@@ -87317,9 +87308,9 @@ ghS
 ghS
 ghS
 kTQ
-cKR
+gcl
 ntC
-cKR
+gcl
 gfI
 qME
 sJf
@@ -87329,18 +87320,18 @@ fln
 gfM
 gfI
 aAs
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
 maW
 whv
 whv
-smz
+jKo
 poH
 tIZ
 poH
@@ -87357,49 +87348,49 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 pKC
 cwo
 fiY
 lwU
 vdf
 jpv
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 xAk
 dIW
-wWG
+ctX
 ldq
 ldq
 oPB
 rSd
-wWG
+ctX
 xSa
 wtu
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 qEy
-chr
-chr
+sME
+sME
 nrE
-tEL
-pxJ
-pxJ
-chr
+yfO
+bcL
+bcL
+sME
 whv
 whv
 whv
@@ -87575,8 +87566,8 @@ ghS
 isk
 kTQ
 mol
-cKR
-cKR
+gcl
+gcl
 gfI
 tIZ
 sOZ
@@ -87584,24 +87575,24 @@ bAL
 gfM
 pVq
 qXj
-smz
+jKo
 gfI
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
 maW
 whv
 whv
-smz
+jKo
 poH
 gfI
 xmO
-smz
+jKo
 tIZ
 poH
 poH
@@ -87614,55 +87605,55 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 rFj
 dBZ
 agN
 wmt
 gcS
 kqD
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 svA
 txn
-wWG
+ctX
 fBQ
 rDy
 kkH
 ckD
-wWG
+ctX
 fFR
 rwR
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 onq
-chr
-chr
-tEL
-chr
-chr
+sME
+sME
+yfO
+sME
+sME
 isq
-chr
-chr
-chr
-chr
-chr
-chr
-chr
+sME
+sME
+sME
+sME
+sME
+sME
+sME
 whv
 whv
 whv
@@ -87823,7 +87814,7 @@ bfM
 cTX
 ewP
 cKR
-ewP
+tIm
 ges
 ges
 bfM
@@ -87832,9 +87823,9 @@ cKR
 kTQ
 kTQ
 iRv
-fww
-cKR
-smz
+pxJ
+gcl
+jKo
 qXj
 tjK
 gfI
@@ -87847,17 +87838,17 @@ wvH
 poH
 poH
 xGQ
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 gfI
 tIZ
 poH
@@ -87871,29 +87862,29 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 rFj
 ovK
 dBZ
 idW
 lwU
 aNa
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-aBC
+pIL
 kXF
 uzA
-wWG
+ctX
 fBQ
 gxN
 kbQ
@@ -87901,22 +87892,22 @@ otg
 lEP
 qCa
 swz
-wWG
+ctX
 whv
 whv
 whv
-chr
-nLo
-chr
-chr
+sME
+aol
+sME
+sME
 xpl
-chr
-chr
+sME
+sME
 isq
 tTp
-tIm
+pHy
 qdf
-pxJ
+bcL
 mti
 xpl
 dyt
@@ -88099,19 +88090,19 @@ gxg
 hsN
 pJe
 kTQ
-smz
+jKo
 wzC
 vvz
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
-smz
+jKo
 poH
 maW
 whv
 whv
-smz
+jKo
 poH
 tIZ
 poH
@@ -88120,63 +88111,63 @@ poH
 poH
 poH
 poH
-smz
+jKo
 gfI
-smz
+jKo
 gfI
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 csB
 lBc
 iar
 dKK
 pcG
 jPX
-wWG
-wWG
+ctX
+ctX
 gTv
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
 svA
 xDs
-wWG
+ctX
 fBQ
-lGf
+kgs
 alF
 otg
 jba
 wuJ
 qee
-wWG
+ctX
 whv
 whv
 whv
-chr
-tEL
-chr
-chr
-chr
-chr
-chr
+sME
+yfO
+sME
+sME
+sME
+sME
+sME
 tJY
-chr
-chr
-chr
-chr
-chr
-chr
-chr
+sME
+sME
+sME
+sME
+sME
+sME
+sME
 whv
 whv
 whv
@@ -88351,24 +88342,24 @@ cKR
 gfI
 rjX
 uqP
-smz
+jKo
 cRz
 nTp
 qXj
 lSJ
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 wzY
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
-smz
+jKo
 poH
 tIZ
 poH
@@ -88385,13 +88376,13 @@ tIZ
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 ski
 pOW
 sqE
@@ -88404,30 +88395,30 @@ lBc
 iar
 vJW
 vJW
-wWG
+ctX
 rTD
 uzA
-wWG
+ctX
 fBQ
 lLz
 uwV
 tka
-wWG
+ctX
 dIW
 gBg
 gTv
 whv
 whv
 whv
-chr
-tEL
+sME
+yfO
 iyt
-tEL
-pxJ
-tEL
+yfO
+bcL
+yfO
 xaZ
 mIo
-chr
+sME
 whv
 whv
 whv
@@ -88613,22 +88604,22 @@ ldy
 eoW
 qXj
 gfI
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
 tVq
 wVU
 ghb
-smz
+jKo
 poH
 maW
 whv
 whv
-smz
+jKo
 poH
 tIZ
-smz
+jKo
 poH
 poH
 poH
@@ -88642,13 +88633,13 @@ poH
 aAs
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 lIg
 ozi
 xlS
@@ -88661,30 +88652,30 @@ iXG
 pcG
 xpf
 lBc
-wWG
+ctX
 uzA
 uLW
-wWG
+ctX
 ldq
 vzT
 ldq
 qcw
-wWG
+ctX
 dIW
 gBg
 gTv
 whv
 whv
 whv
-chr
-chr
-chr
-chr
-chr
-chr
-chr
+sME
+sME
+sME
+sME
+sME
+sME
+sME
 cic
-chr
+sME
 whv
 whv
 whv
@@ -88861,28 +88852,28 @@ ghS
 cKR
 ges
 cKR
-fww
-smz
+pxJ
+jKo
 rNp
 vBw
 qXj
 iJT
 qXj
 qXj
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
-smz
+jKo
 tIZ
 peA
 poH
@@ -88899,13 +88890,13 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 pEv
 lBc
 tEa
@@ -88918,18 +88909,18 @@ wLy
 oKf
 vYB
 lBc
-wWG
+ctX
 xgZ
 dIW
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 swz
 xAk
-wWG
+ctX
 wWG
 wWG
 wWG
@@ -88939,9 +88930,9 @@ whv
 whv
 whv
 whv
-chr
+sME
 jkO
-chr
+sME
 whv
 whv
 whv
@@ -89119,27 +89110,27 @@ cws
 cws
 whv
 whv
-smz
+jKo
 gfI
-smz
+jKo
 gfI
 pld
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
-smz
+jKo
 vOG
 urQ
 nIu
@@ -89156,37 +89147,37 @@ qpS
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 rFj
 jOF
 tEa
 lwU
 lwU
 gGC
-wWG
-wWG
+ctX
+ctX
 aSe
-wWG
-wWG
+ctX
+ctX
 xpb
-wWG
+ctX
 lqi
 dIW
-wWG
+ctX
 nzx
 hNu
 cab
 oTE
-wWG
+ctX
 fXV
 jqh
-wWG
+ctX
 bXz
 bwf
 csi
@@ -89196,11 +89187,11 @@ whv
 whv
 whv
 whv
-chr
+sME
 nej
-chr
-chr
-chr
+sME
+sME
+sME
 whv
 whv
 whv
@@ -89376,7 +89367,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 skv
 sBH
 poH
@@ -89384,21 +89375,21 @@ poH
 poH
 sBH
 sBH
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
 gfI
-vMz
-ptZ
+tEL
+hii
 nIu
 poH
 poH
@@ -89413,24 +89404,24 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 rKI
 wNV
 oFd
 itw
 jIr
 sCt
-wWG
+ctX
 auV
 wWr
 ego
-wWG
+ctX
 wIR
 myM
 qee
@@ -89440,7 +89431,7 @@ fAx
 sfM
 nCB
 ikC
-wWG
+ctX
 xAk
 xAk
 jba
@@ -89453,11 +89444,11 @@ whv
 whv
 whv
 whv
-chr
+sME
 jlH
-tEL
+yfO
 xpl
-chr
+sME
 whv
 whv
 whv
@@ -89633,7 +89624,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 poH
 poH
@@ -89641,19 +89632,19 @@ mBH
 poH
 dNj
 poH
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
-smz
+jKo
 adl
 wbK
 poH
@@ -89670,13 +89661,13 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 bqc
 rPO
 nkb
@@ -89692,29 +89683,29 @@ phP
 myM
 akF
 kFg
-wWG
+ctX
 pKm
 cab
 cab
 uDN
-wWG
-dnN
+ctX
+swD
 pKa
-wWG
+ctX
 rQk
 mfE
 dhT
 bWu
 wWG
-wWG
-wWG
-wWG
-wWG
-chr
-tIm
-chr
-chr
-chr
+ctX
+ctX
+ctX
+ctX
+sME
+pHy
+sME
+sME
+sME
 whv
 whv
 whv
@@ -89890,27 +89881,27 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 xkL
 kWz
-smz
+jKo
 knc
 poH
 poH
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 whv
 whv
-smz
+jKo
 adl
 nIu
 poH
@@ -89927,49 +89918,49 @@ poH
 dsN
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 gox
 lwU
 xKA
 eQN
 tEa
 puL
-wWG
+ctX
 hER
 efh
 bRJ
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 swz
 xAk
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 xwU
 kXF
+ctX
 wWG
 wWG
 wWG
 wWG
 wWG
-wWG
-aBC
-tEL
+pIL
+yfO
 nps
-tEL
-chr
-kgs
-chr
+yfO
+sME
+kce
+sME
 whv
 whv
 whv
@@ -90147,7 +90138,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 poH
 poH
 poH
@@ -90155,16 +90146,16 @@ vWM
 poH
 poH
 poH
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 ghS
 ghS
 gfI
@@ -90177,56 +90168,56 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 dsN
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 eoP
 jMq
 pQJ
 pQJ
 rzW
 iZc
-wWG
-wWG
-aBC
-wWG
-wWG
+ctX
+ctX
+pIL
+ctX
+ctX
 whv
-wWG
+ctX
 xAk
 dpV
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
+ctX
 nbG
 xKZ
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
-wWG
-chr
-pxJ
-chr
-tEL
-chr
+ctX
+ctX
+sME
+bcL
+sME
+yfO
+sME
 whv
 whv
 whv
@@ -90404,7 +90395,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 sBH
 sBH
 poH
@@ -90412,16 +90403,16 @@ poH
 poH
 sBH
 sBH
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 ghS
 vMz
 oTw
@@ -90441,49 +90432,49 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 jqZ
 gXm
 jAq
 oYF
 jXM
 gSg
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 myD
 sSq
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
-dnN
+ctX
+swD
 svA
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
-chr
-pxJ
-chr
-tIm
-chr
+sME
+bcL
+sME
+pHy
+sME
 whv
 whv
 whv
@@ -90661,27 +90652,27 @@ whv
 whv
 whv
 whv
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 ghS
 dMX
-ptZ
+hii
 xtA
 tIZ
 poH
@@ -90698,49 +90689,49 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 vCG
 sqn
 pLp
 pLp
 pLp
 qza
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 iwm
 khO
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
+ctX
 xAk
-dnN
-wWG
+swD
+ctX
 sgZ
 ndB
 nUd
 gUn
-wWG
+ctX
 whv
 whv
-chr
+sME
 nej
-chr
+sME
 isq
-chr
+sME
 whv
 whv
 whv
@@ -90938,51 +90929,51 @@ ghS
 ghS
 ghS
 dMX
-ghS
+bQT
 gfI
-smz
+jKo
 gfI
-smz
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 gfI
-smz
+jKo
 poH
 gfI
 gfI
-smz
-smz
+jKo
+jKo
 whv
 whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
 wwE
-wWG
-wWG
+ctX
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 bRI
 xAk
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
+ctX
 dRM
 uzA
 jba
@@ -90990,14 +90981,14 @@ btQ
 btQ
 ngw
 btQ
-wWG
+ctX
 whv
 whv
-chr
+sME
 aNf
-chr
+sME
 xaZ
-chr
+sME
 whv
 whv
 whv
@@ -91205,13 +91196,13 @@ whv
 whv
 whv
 whv
-smz
+jKo
 skv
 sBH
 poH
 skv
 sBH
-smz
+jKo
 whv
 whv
 whv
@@ -91220,41 +91211,41 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 fsi
 xAk
 xAk
 wDG
-wWG
+ctX
 whv
 whv
 whv
 whv
 whv
-wWG
+ctX
 cpR
 xAk
-wWG
+ctX
 whv
 whv
 whv
 whv
-wWG
+ctX
 uzA
 fFV
-wWG
+ctX
 oPG
 fdE
 uqm
 btQ
-wWG
+ctX
 whv
 whv
-chr
+sME
 uLB
-chr
-tEL
-chr
+sME
+yfO
+sME
 whv
 whv
 whv
@@ -91462,7 +91453,7 @@ whv
 whv
 whv
 whv
-smz
+jKo
 aAs
 poH
 poH
@@ -91477,41 +91468,41 @@ whv
 whv
 whv
 whv
-aBC
+pIL
 lei
 uzA
 eqc
 wDG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 nES
 tKy
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 khO
 khO
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 tTp
-wWG
-wWG
-chr
-chr
-chr
-kgs
+ctX
+ctX
+sME
+sME
+sME
+kce
 bCx
 usG
-chr
+sME
 whv
 whv
 whv
@@ -91719,13 +91710,13 @@ whv
 whv
 whv
 whv
-smz
+jKo
 skv
 sBH
 poH
 skv
 sBH
-smz
+jKo
 whv
 whv
 whv
@@ -91734,7 +91725,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 ycv
 dIW
 dIW
@@ -91756,19 +91747,19 @@ svA
 ufy
 xAk
 svA
-wWG
+ctX
 whv
-chr
+sME
 iCw
 geq
 apS
-tIm
+pHy
 aNS
 nps
 aoa
-tIm
-kgs
-chr
+pHy
+kce
+sME
 whv
 whv
 whv
@@ -91982,7 +91973,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -91991,7 +91982,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 osk
 uzA
 xAk
@@ -92013,19 +92004,19 @@ svA
 vRQ
 svA
 qRQ
-wWG
+ctX
 whv
-chr
-chr
-chr
-chr
-chr
-chr
-wWG
-tEL
-chr
-chr
-chr
+sME
+sME
+sME
+sME
+sME
+sME
+ctX
+yfO
+sME
+sME
+sME
 whv
 whv
 whv
@@ -92239,7 +92230,7 @@ oiP
 poH
 pYz
 oiP
-smz
+jKo
 whv
 whv
 whv
@@ -92248,29 +92239,29 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 iOi
 rrM
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -92278,9 +92269,9 @@ whv
 whv
 whv
 whv
-chr
+sME
 nrE
-chr
+sME
 whv
 whv
 whv
@@ -92494,9 +92485,9 @@ gfI
 gfI
 gfI
 gfI
-smz
-smz
-smz
+jKo
+jKo
+jKo
 whv
 whv
 whv
@@ -92516,28 +92507,28 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 bVe
 svA
-wWG
+ctX
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
-chr
+sME
 vTu
-chr
+sME
 whv
 whv
 whv
@@ -92773,14 +92764,14 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 mKB
 xOv
-wWG
+ctX
 whv
 whv
 whv
-wWG
+ctX
 jAs
 qjR
 oPl
@@ -92789,12 +92780,12 @@ tTI
 lxz
 fDq
 trP
-wWG
+ctX
 whv
 whv
-chr
-tEL
-chr
+sME
+yfO
+sME
 whv
 whv
 whv
@@ -93030,28 +93021,28 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 kXF
 eVW
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
 hOP
 jIg
 dFW
-vKE
+smz
 rwb
 bTK
 cdW
 qIo
-wWG
-chr
+ctX
+sME
 wRp
 wRp
-kgs
-chr
+kce
+sME
 whv
 whv
 whv
@@ -93287,14 +93278,14 @@ whv
 whv
 whv
 whv
-aBC
+pIL
 gjo
 mLs
 erI
 bcw
 vgM
 xks
-wWG
+ctX
 eGO
 cdW
 gLy
@@ -93303,12 +93294,12 @@ urE
 cdW
 cEq
 eMf
-wWG
-tEL
+ctX
+yfO
 haJ
-pxJ
-tEL
-chr
+bcL
+yfO
+sME
 whv
 whv
 whv
@@ -93544,14 +93535,14 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 xSa
 dIW
 gEQ
 kXS
 iTM
 ciT
-wWG
+ctX
 iZx
 xLD
 qYV
@@ -93560,12 +93551,12 @@ eaR
 hqb
 glE
 xVA
-wWG
-tEL
-wWG
-wWG
-tEL
-wWG
+ctX
+yfO
+ctX
+ctX
+yfO
+ctX
 whv
 whv
 whv
@@ -93801,14 +93792,14 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 iMS
 hNP
 lsH
 cZg
-cka
+ijt
 tnj
-wWG
+ctX
 tMt
 cdW
 rwb
@@ -93817,12 +93808,12 @@ siY
 tns
 oPl
 cOz
-wWG
+ctX
 tTp
-wWG
-wWG
+ctX
+ctX
 tTp
-wWG
+ctX
 whv
 whv
 whv
@@ -94058,28 +94049,28 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 eSn
 kZK
 vaM
 lsH
-cka
+ijt
 erI
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 fIS
-wWG
+ctX
 fIS
-wWG
+ctX
 fIS
-wWG
-wWG
-tEL
-wWG
-wWG
-aBC
-wWG
+ctX
+ctX
+yfO
+ctX
+ctX
+pIL
+ctX
 whv
 whv
 whv
@@ -94315,7 +94306,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 svA
 wDG
 oHa
@@ -94331,12 +94322,12 @@ svA
 rvX
 svA
 mTH
-wWG
+ctX
 tTp
-wWG
-wWG
+ctX
+ctX
 tTp
-wWG
+ctX
 whv
 whv
 whv
@@ -94572,7 +94563,7 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 gCY
 svA
 uzA
@@ -94588,12 +94579,12 @@ myY
 whB
 orB
 lOQ
-wWG
-tEL
-wWG
-wWG
-tEL
-wWG
+ctX
+yfO
+ctX
+ctX
+yfO
+ctX
 whv
 whv
 whv
@@ -94829,28 +94820,28 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-aBC
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+pIL
+ctX
+ctX
+ctX
 vRO
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 rfT
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 dcj
-tEL
-tEL
-tIm
-chr
+yfO
+yfO
+pHy
+sME
 whv
 whv
 whv
@@ -95093,21 +95084,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 bAn
 pPO
 tbI
-wWG
+ctX
 tbI
 oYI
 iFy
-wWG
-wWG
-chr
-chr
-chr
+ctX
+ctX
+sME
+sME
+sME
 vze
-chr
+sME
 whv
 whv
 whv
@@ -95290,24 +95281,24 @@ maW
 maW
 maW
 maW
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 maW
-smz
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
+jKo
 fqN
 maW
 maW
 maW
-smz
+jKo
 whv
 whv
 whv
@@ -95350,21 +95341,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 xhb
 ejP
 eTP
-wWG
+ctX
 the
 tDC
 lwq
-wWG
-wWG
+ctX
+ctX
 whv
 whv
-chr
+sME
 dpm
-chr
+sME
 whv
 whv
 whv
@@ -95545,7 +95536,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 poH
 poH
 poH
@@ -95564,7 +95555,7 @@ iVJ
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -95607,21 +95598,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 eBH
 lnt
 ixN
-wWG
+ctX
 vxs
 oYI
 iYR
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 nnj
-chr
+sME
 whv
 whv
 whv
@@ -95802,12 +95793,12 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
 poH
 poH
@@ -95821,7 +95812,7 @@ bkF
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -95864,21 +95855,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 the
 hlJ
 pcD
-aBC
+pIL
 mhQ
 oYI
 tpU
-wWG
+ctX
 whv
 whv
 whv
-chr
-pxJ
-chr
+sME
+bcL
+sME
 whv
 whv
 whv
@@ -96061,24 +96052,24 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
-smz
-poH
-poH
+jKo
 poH
 poH
 poH
-smz
-smz
+poH
+poH
+jKo
+jKo
 maW
 poH
 poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -96121,21 +96112,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 iwK
 elk
 tZS
-wWG
+ctX
 lng
 oYI
 iFy
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 onq
-chr
+sME
 whv
 whv
 whv
@@ -96315,15 +96306,15 @@ maW
 poH
 poH
 poH
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
 poH
 poH
 poH
-smz
+jKo
 poH
 poH
 poH
@@ -96331,11 +96322,11 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -96378,21 +96369,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 ktk
 qES
 uUY
-wWG
+ctX
 pcD
 wot
 eTP
-wWG
+ctX
 whv
 whv
 whv
-chr
-pxJ
-chr
+sME
+bcL
+sME
 whv
 whv
 whv
@@ -96571,28 +96562,28 @@ whv
 maW
 poH
 poH
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 maW
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -96635,21 +96626,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 wUV
 dVY
 eBe
-wWG
+ctX
 kFo
 dfy
 wUV
-wWG
+ctX
 whv
 whv
 whv
-chr
+sME
 nrE
-chr
+sME
 whv
 whv
 whv
@@ -96834,22 +96825,22 @@ poH
 poH
 poH
 poH
-smz
-smz
-smz
+jKo
+jKo
+jKo
 poH
 poH
 maW
-smz
+jKo
 poH
 poH
-smz
+jKo
 poH
 poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -96892,21 +96883,21 @@ whv
 whv
 whv
 whv
-wWG
-wWG
+ctX
+ctX
 apd
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
 apd
-wWG
-wWG
-chr
-chr
-chr
-chr
-pxJ
-chr
+ctX
+ctX
+sME
+sME
+sME
+sME
+bcL
+sME
 whv
 whv
 whv
@@ -97091,8 +97082,8 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
@@ -97100,13 +97091,13 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 whv
 whv
 whv
@@ -97149,21 +97140,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 tBy
 vUC
 kQi
-wWG
+ctX
 skW
 auw
 cun
 wlc
-kgs
+kce
 aKO
 xIH
 xaZ
 lPm
-chr
+sME
 whv
 whv
 bLi
@@ -97343,27 +97334,27 @@ maW
 poH
 poH
 poH
-smz
+jKo
 poH
 poH
-smz
+jKo
 poH
 poH
-smz
+jKo
 poH
-smz
-poH
-maW
+jKo
 poH
 maW
 poH
+maW
 poH
 poH
 poH
 poH
 poH
 poH
-smz
+poH
+jKo
 whv
 whv
 whv
@@ -97406,21 +97397,21 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 nxS
 tHf
 isE
-wWG
+ctX
 wwX
 tHf
 nxS
-wWG
-chr
-chr
-chr
-chr
+ctX
+sME
+sME
+sME
+sME
 eYG
-chr
+sME
 whv
 whv
 whv
@@ -97600,10 +97591,10 @@ maW
 poH
 poH
 poH
-smz
+jKo
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
@@ -97616,11 +97607,11 @@ poH
 poH
 poH
 poH
-smz
+jKo
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -97663,21 +97654,21 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
-chr
-pxJ
-chr
+sME
+bcL
+sME
 whv
 whv
 whv
@@ -97875,9 +97866,9 @@ poH
 poH
 poH
 poH
-smz
+jKo
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -97932,13 +97923,13 @@ whv
 whv
 whv
 whv
-chr
-tIm
-chr
-chr
-chr
-chr
-chr
+sME
+pHy
+sME
+sME
+sME
+sME
+sME
 whv
 whv
 whv
@@ -98134,7 +98125,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -98189,13 +98180,13 @@ whv
 whv
 whv
 whv
-chr
-tEL
+sME
+yfO
 nrE
 qdf
-pxJ
-tEL
-chr
+bcL
+yfO
+sME
 whv
 whv
 whv
@@ -98372,8 +98363,8 @@ maW
 poH
 maW
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
@@ -98391,7 +98382,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -98447,12 +98438,12 @@ whv
 whv
 whv
 chr
-chr
-chr
-chr
+sME
+sME
+sME
 wRp
-tEL
-chr
+yfO
+sME
 whv
 whv
 whv
@@ -98648,7 +98639,7 @@ poH
 maW
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -98704,12 +98695,12 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
 tTp
-wWG
+ctX
 whv
 whv
 whv
@@ -98886,8 +98877,8 @@ maW
 poH
 poH
 maW
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
@@ -98905,7 +98896,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -98961,12 +98952,12 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 uqr
 rZI
-pxJ
-tEL
-wWG
+bcL
+yfO
+ctX
 whv
 whv
 whv
@@ -99145,11 +99136,11 @@ maW
 maW
 poH
 maW
-smz
-smz
-smz
-smz
-smz
+jKo
+jKo
+jKo
+jKo
+jKo
 poH
 maW
 poH
@@ -99162,7 +99153,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -99218,12 +99209,12 @@ whv
 whv
 whv
 whv
-wWG
+ctX
 qUD
 vze
-pxJ
+bcL
 vvB
-wWG
+ctX
 whv
 whv
 whv
@@ -99419,7 +99410,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -99475,12 +99466,12 @@ whv
 whv
 whv
 whv
-wWG
-wWG
-wWG
-wWG
-wWG
-wWG
+ctX
+ctX
+ctX
+ctX
+ctX
+ctX
 whv
 whv
 whv
@@ -99676,7 +99667,7 @@ poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -99927,13 +99918,13 @@ poH
 poH
 poH
 poH
-smz
-smz
+jKo
+jKo
 poH
 poH
 poH
 poH
-smz
+jKo
 whv
 whv
 whv
@@ -100170,27 +100161,27 @@ maW
 maW
 maW
 maW
-smz
+jKo
 maW
 maW
-smz
+jKo
 maW
-smz
-smz
+jKo
+jKo
 maW
-smz
-maW
-maW
+jKo
 maW
 maW
 maW
-smz
-smz
 maW
 maW
-smz
-smz
-smz
+jKo
+jKo
+maW
+maW
+jKo
+jKo
+jKo
 whv
 whv
 whv

--- a/_maps/map_files/Pahrump-AB/Pahrump-AB-Lower.dmm
+++ b/_maps/map_files/Pahrump-AB/Pahrump-AB-Lower.dmm
@@ -72,7 +72,7 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "aaY" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -192,7 +192,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 6
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "agO" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
@@ -289,7 +289,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "alR" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/inside/mountain,
@@ -321,7 +321,7 @@
 	},
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "anO" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/f13{
@@ -339,7 +339,7 @@
 "aoG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "aoM" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -347,7 +347,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel,
-/area/f13/caves)
+/area/f13/bunker)
 "aoU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -369,7 +369,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "apd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
@@ -460,7 +460,7 @@
 /area/f13/caves)
 "asR" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "atk" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -488,7 +488,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aul" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -519,7 +519,7 @@
 	},
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "awc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/simple_door/metal/barred,
@@ -596,7 +596,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "axS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/ash_rock,
@@ -623,7 +623,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "azk" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/museum)
@@ -727,14 +727,14 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "aFk" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "aFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/raider,
@@ -766,7 +766,7 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "aGy" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -784,7 +784,7 @@
 	layer = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "aHf" = (
 /obj/machinery/button/door{
 	id = "militarystorage2";
@@ -848,7 +848,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "aKO" = (
 /obj/structure/simple_door/room{
 	name = "restroom"
@@ -864,7 +864,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aKW" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -875,7 +875,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "aLC" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -908,7 +908,7 @@
 /mob/living/simple_animal/bot/cleanbot,
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "aMv" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -964,7 +964,7 @@
 /turf/open/floor/f13{
 	icon_state = "damaged4"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aPS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -973,7 +973,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aQd" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -985,7 +985,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "aQF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -999,11 +999,11 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aRI" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "aRY" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -1019,7 +1019,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aSt" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1079,7 +1079,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "aXf" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1095,7 +1095,7 @@
 /area/f13/bunker)
 "aXo" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "aYa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -1130,7 +1130,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "bad" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1138,7 +1138,7 @@
 "bao" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "baB" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1"
@@ -1157,7 +1157,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "bbT" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -1169,7 +1169,7 @@
 "bbV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
@@ -1229,7 +1229,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "bhq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1240,7 +1240,7 @@
 "bhH" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "bhP" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13/wood,
@@ -1272,11 +1272,11 @@
 	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "bix" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "biB" = (
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
@@ -1298,14 +1298,14 @@
 "biK" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "biP" = (
 /obj/structure/decoration/vent,
 /obj/effect/overlay/junk/shower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "biU" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/turf_decal/weather/dirt{
@@ -1366,7 +1366,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "bmN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -1399,7 +1399,7 @@
 	radius = 2
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "bnB" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1449,7 +1449,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "bqN" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -1491,7 +1491,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "bsC" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
@@ -1508,14 +1508,14 @@
 /obj/effect/decal/fakelattice,
 /obj/item/shard,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "btl" = (
 /obj/structure/wreck/trash/machinepile{
 	layer = 3
 	},
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "bty" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/effect/decal/cleanable/dirt,
@@ -1535,7 +1535,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "buA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -1589,7 +1589,7 @@
 	layer = 3
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "bwO" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1664,7 +1664,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "bzD" = (
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -1673,7 +1673,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "bzQ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -1798,7 +1798,7 @@
 "bDu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "bDN" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
@@ -1855,7 +1855,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "bGd" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Tunnel Torturers Raider"
@@ -2166,7 +2166,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "bHU" = (
 /mob/living/simple_animal/hostile/supermutant,
 /obj/effect/decal/cleanable/dirt,
@@ -2193,11 +2193,11 @@
 "bIa" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "bIb" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "bIe" = (
 /mob/living/simple_animal/hostile/supermutant,
 /obj/effect/decal/cleanable/dirt,
@@ -4351,7 +4351,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "bQM" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -4752,7 +4752,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "bUM" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -4992,7 +4992,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "cae" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5020,7 +5020,7 @@
 "cat" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "caR" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt{
@@ -5031,7 +5031,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "caX" = (
 /obj/structure/nest/assaultron,
 /turf/open/floor/f13{
@@ -5111,7 +5111,7 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/caves)
+/area/f13/bunker)
 "ceq" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/light/small{
@@ -5559,7 +5559,7 @@
 "ckr" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "cks" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -5751,7 +5751,7 @@
 /obj/item/grenade/chem_grenade/teargas,
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "cov" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/closed/mineral/random/high_chance,
@@ -5881,7 +5881,7 @@
 /obj/structure/bed/old,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "csU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -5903,7 +5903,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "ctH" = (
 /obj/machinery/light{
 	dir = 1
@@ -5916,7 +5916,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "ctU" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -5997,7 +5997,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "cvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -6086,7 +6086,7 @@
 /obj/machinery/iv_drip,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "cyq" = (
 /obj/item/clothing/suit/armor/light/duster/bos/scribe,
 /obj/item/clothing/accessory/bos/initiateS,
@@ -6215,14 +6215,14 @@
 /obj/structure/wreck/trash/engine,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "cBX" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "cDg" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -6245,7 +6245,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "cDB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6275,7 +6275,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "cGl" = (
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
@@ -6288,7 +6288,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "cHM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
@@ -6335,7 +6335,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "cKH" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -6403,7 +6403,7 @@
 "cOD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "cOY" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -6454,7 +6454,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "cQy" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6473,7 +6473,7 @@
 "cQQ" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "cRu" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -6569,7 +6569,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "cVE" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -6591,7 +6591,7 @@
 "cWV" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "cXk" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -6610,7 +6610,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "cYM" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -6641,7 +6641,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "cZU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -6657,7 +6657,7 @@
 "dak" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "das" = (
 /obj/machinery/light{
 	dir = 8
@@ -6669,7 +6669,7 @@
 	layer = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "dau" = (
 /obj/structure/guncase,
 /obj/item/gun/energy/laser/plasma/glock,
@@ -6697,7 +6697,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dbr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -6721,7 +6721,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "ddz" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -6733,7 +6733,7 @@
 "ddH" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "deg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6757,7 +6757,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dfy" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
@@ -6779,14 +6779,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "dgz" = (
 /obj/structure/junk/small/bed,
 /obj/item/radio/off,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dgO" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -6827,7 +6827,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "djQ" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -6839,7 +6839,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "djV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -6862,7 +6862,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "dlb" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -6924,7 +6924,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dnp" = (
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6956,7 +6956,7 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "dog" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -7000,7 +7000,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "dpM" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -7010,7 +7010,7 @@
 "dqz" = (
 /obj/item/electronic_assembly/drone/medbot,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "dqZ" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosarmoryacc";
@@ -7057,7 +7057,7 @@
 	amount = 25
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "duJ" = (
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/dirt,
@@ -7071,12 +7071,12 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "dwr" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "dwM" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/tribal,
@@ -7108,7 +7108,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "dzm" = (
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
@@ -7130,7 +7130,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dAy" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -7140,7 +7140,7 @@
 "dAH" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "dAT" = (
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/floor/plasteel/dark,
@@ -7330,7 +7330,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dHX" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -7339,7 +7339,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dHZ" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -7397,7 +7397,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "dKT" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -7405,14 +7405,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "dKV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "dLk" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -7513,7 +7513,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "dRN" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/indestructible/ground/inside/subway,
@@ -7541,7 +7541,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "dSY" = (
 /obj/structure/closet/secure_closet/goodies{
 	anchorable = 0;
@@ -7672,7 +7672,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "dWL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -7723,7 +7723,7 @@
 	name = "counter shutters"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "dYU" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/turf_decal/weather/dirt{
@@ -7761,7 +7761,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -7809,7 +7809,7 @@
 "edw" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "edy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /mob/living/simple_animal/hostile/radroach,
@@ -7830,7 +7830,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "edO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -7864,7 +7864,7 @@
 "egj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "ehh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7886,7 +7886,7 @@
 	},
 /obj/item/book/granter/trait/midsurgery,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "eiq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -7993,7 +7993,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "eoT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8041,7 +8041,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "eqi" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/black,
@@ -8076,7 +8076,7 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "erT" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/indestructible/ground/inside/subway,
@@ -8089,7 +8089,7 @@
 "esI" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "esK" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb,
@@ -8102,7 +8102,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "esO" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/subway,
@@ -8137,7 +8137,7 @@
 "etm" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "etz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/fulltile/wood_window,
@@ -8166,7 +8166,7 @@
 /area/f13/caves)
 "euT" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "euX" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -8218,11 +8218,11 @@
 	req_one_access_txt = ""
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "ewW" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "ewY" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -8292,7 +8292,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "eyK" = (
 /obj/structure/closet/locker,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -8310,30 +8310,30 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "ezm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "ezZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "eAj" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "eAl" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "eAA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel{
@@ -8382,7 +8382,7 @@
 "eCX" = (
 /obj/machinery/light/small,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "eDd" = (
 /obj/structure/chair/stool/retro/black,
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker{
@@ -8408,10 +8408,10 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/burger/rib,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "eDO" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "eDP" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -8444,7 +8444,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "eFZ" = (
 /obj/machinery/light/broken,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -8484,7 +8484,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "eHm" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -8504,7 +8504,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "eIb" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -8556,7 +8556,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "eKs" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -8577,7 +8577,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "eKC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -8588,7 +8588,7 @@
 "eLf" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "eLh" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/generic,
@@ -8609,7 +8609,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "eNm" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8625,7 +8625,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "eNE" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8693,7 +8693,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "ePX" = (
 /obj/structure/junk/jukebox,
 /obj/effect/decal/cleanable/dirt,
@@ -8705,7 +8705,7 @@
 	layer = 3
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "eQX" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -8887,7 +8887,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "eZW" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/healing_kits,
@@ -8901,7 +8901,7 @@
 /area/f13/caves)
 "fap" = (
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "fbR" = (
 /obj/structure/chair/left,
 /turf/open/floor/f13/wood,
@@ -8935,7 +8935,7 @@
 	pixel_y = -9
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "fdB" = (
 /obj/structure/rack/large/shelf_rust,
 /obj/item/storage/box/ration/menu_four,
@@ -8954,7 +8954,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "feI" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -9014,7 +9014,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 6
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "fib" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -9045,14 +9045,14 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "flz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "flD" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -9091,7 +9091,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "foJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9181,7 +9181,7 @@
 	},
 /obj/structure/nest/supermutant,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "fuG" = (
 /obj/machinery/door_timer{
 	id = "vaultc2";
@@ -9191,7 +9191,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "fuQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway{
@@ -9223,7 +9223,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "fwI" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
@@ -9242,14 +9242,14 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "fyp" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "fyO" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -9297,7 +9297,7 @@
 "fBd" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "fBq" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -9308,7 +9308,7 @@
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "fBw" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
@@ -9337,7 +9337,7 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/showcase/machinery/cloning_pod,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "fEJ" = (
 /obj/structure/table/optable/primitive,
 /obj/machinery/iv_drip/primitive{
@@ -9399,7 +9399,7 @@
 /area/f13/building/hospital)
 "fIt" = (
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "fIB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
@@ -9473,7 +9473,7 @@
 "fMO" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "fNb" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt{
@@ -9499,7 +9499,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "fNM" = (
 /obj/machinery/computer/card/enclave{
 	dir = 4
@@ -9514,7 +9514,7 @@
 	},
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "fOD" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -9533,7 +9533,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "fQm" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/effect/decal/cleanable/dirt,
@@ -9595,7 +9595,7 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "fTM" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -9631,7 +9631,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "fWG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9656,13 +9656,13 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "fXU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "fYG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
@@ -9674,14 +9674,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "fZg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "fZx" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -9720,7 +9720,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "gbL" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -9803,7 +9803,7 @@
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "ghO" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/salvage/low,
@@ -9830,7 +9830,7 @@
 "gio" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "giB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/locker,
@@ -9879,11 +9879,11 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "gkH" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "gkJ" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9931,7 +9931,7 @@
 "gmM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "gmY" = (
 /obj/item/flashlight/flare,
 /turf/open/floor/f13{
@@ -9948,7 +9948,7 @@
 /obj/structure/table,
 /obj/item/storage/box/pillbottles,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "gnW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge/cannibal,
@@ -10021,14 +10021,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "grQ" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "gti" = (
 /obj/structure/rack,
 /obj/item/gun/medbeam,
@@ -10085,14 +10085,14 @@
 	pixel_y = 15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "guN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "gvg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -10130,7 +10130,7 @@
 	},
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "gwX" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bottle/FEV_solution,
@@ -10157,7 +10157,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "gxO" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -10168,7 +10168,7 @@
 /obj/item/stock_parts/cell/ammo/ec,
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/darkred/side,
-/area/f13/caves)
+/area/f13/bunker)
 "gyy" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/line{
@@ -10309,7 +10309,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "gCc" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -10420,7 +10420,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "gGV" = (
 /turf/open/water,
 /area/f13/caves)
@@ -10444,7 +10444,7 @@
 	},
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "gHs" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10466,7 +10466,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "gHC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -10498,7 +10498,7 @@
 "gJu" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "gJx" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/carpet/black,
@@ -10589,7 +10589,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "gOh" = (
 /obj/machinery/light{
 	dir = 4
@@ -10702,7 +10702,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "gRT" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spider/stickyweb,
@@ -10738,7 +10738,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "gTA" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -10815,7 +10815,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "gZX" = (
 /obj/structure/table/wood,
 /obj/structure/railing{
@@ -10851,7 +10851,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "hbb" = (
 /obj/machinery/light{
 	dir = 4
@@ -10870,11 +10870,11 @@
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "hdC" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "hef" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -10933,7 +10933,7 @@
 /obj/effect/decal/fakelattice,
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hgv" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10988,7 +10988,7 @@
 	},
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "hil" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
@@ -11000,7 +11000,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "hir" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -11049,7 +11049,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hkn" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -11132,7 +11132,7 @@
 	},
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hoq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11164,7 +11164,7 @@
 	icon_state = "gibtorso"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "hoP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/old,
@@ -11181,7 +11181,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "hqq" = (
 /mob/living/simple_animal/hostile/raider/sulphite{
 	name = "Tunnel Torturers Lieutenant"
@@ -11195,7 +11195,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "hrd" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -11221,7 +11221,7 @@
 "hsb" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "hsH" = (
 /obj/structure/rack,
 /obj/item/melee/coyote/crudeblade,
@@ -11255,7 +11255,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "htL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance/underground,
@@ -11263,7 +11263,7 @@
 "htW" = (
 /obj/machinery/smartfridge,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "huc" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -11380,7 +11380,7 @@
 /obj/machinery/iv_drip,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "hAW" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /obj/effect/decal/waste{
@@ -11417,7 +11417,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hCV" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -11470,7 +11470,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "hGn" = (
 /obj/machinery/button/door{
 	id = "bosfrontgate";
@@ -11509,7 +11509,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hHu" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -11555,16 +11555,16 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hJb" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hJe" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/floor/plating/dirt/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "hJD" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11598,7 +11598,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hLa" = (
 /obj/machinery/conveyor/inverted{
 	dir = 8;
@@ -11610,7 +11610,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "hMJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
@@ -11669,7 +11669,7 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "hQf" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
@@ -11693,7 +11693,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hSR" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -11760,7 +11760,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hWr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/old,
@@ -11775,24 +11775,24 @@
 "hWD" = (
 /obj/effect/mob_spawn/human/corpse/vault/security,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "hWS" = (
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "hXb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
 	req_access_txt = "45; 5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "hXz" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "hZd" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -11800,7 +11800,7 @@
 	},
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "hZi" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -11810,13 +11810,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "hZN" = (
 /obj/structure/lattice{
 	layer = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "iae" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13{
@@ -11873,7 +11873,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "idg" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -11892,7 +11892,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "idq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11916,7 +11916,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "iej" = (
 /obj/structure/handrail/g_central{
 	layer = 2.7;
@@ -11995,7 +11995,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/f13,
-/area/f13/caves)
+/area/f13/bunker)
 "ikO" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -12006,7 +12006,7 @@
 "ikT" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "ild" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -12042,13 +12042,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "imo" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "imz" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -12064,7 +12064,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "inc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -12136,7 +12136,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "iqw" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -12150,7 +12150,7 @@
 "iqJ" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/area/f13/bunker)
 "iqW" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -12163,7 +12163,7 @@
 "ira" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "irr" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -12171,7 +12171,7 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "irs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution{
@@ -12208,12 +12208,12 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 9
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "isv" = (
 /obj/structure/barricade/wooden,
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "isI" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -12241,7 +12241,7 @@
 	},
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "itK" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /obj/effect/decal/cleanable/dirt,
@@ -12262,12 +12262,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "iul" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "iuw" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -12279,7 +12279,7 @@
 	name = "occupied cloning pod"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "iuz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/metal/barred,
@@ -12366,7 +12366,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "iAq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -12409,7 +12409,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "iBf" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -12443,7 +12443,7 @@
 "iCK" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "iCX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -12466,7 +12466,7 @@
 /obj/item/reagent_containers/food/snacks/burger/rib,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "iDr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -12481,7 +12481,7 @@
 	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "iDZ" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -12521,7 +12521,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "iGz" = (
 /obj/machinery/light{
 	dir = 1
@@ -12557,7 +12557,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "iHK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
@@ -12585,12 +12585,12 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "iJZ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "iKc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -12650,7 +12650,7 @@
 "iLK" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "iLM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12662,7 +12662,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "iLR" = (
 /obj/structure/sink{
 	dir = 4;
@@ -12710,7 +12710,7 @@
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "iOS" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -12729,21 +12729,21 @@
 /obj/structure/bedsheetbin,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "iQE" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "iQG" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "iRD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12799,7 +12799,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "iTT" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -12825,7 +12825,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "iVo" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/floor/f13/wood,
@@ -12907,9 +12907,8 @@
 /turf/open/water,
 /area/f13/caves)
 "iYN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/bunker)
 "iYT" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -12926,11 +12925,11 @@
 	},
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "iZw" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "jak" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/mineral/random/low_chance,
@@ -12962,7 +12961,7 @@
 "jbz" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jbA" = (
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -12980,7 +12979,7 @@
 "jbM" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jct" = (
 /obj/structure/debris/v3{
 	pixel_y = -10
@@ -12996,7 +12995,7 @@
 /obj/item/bedsheet/blue,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jcE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -13015,7 +13014,7 @@
 	},
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "jdv" = (
 /obj/structure/wreck/trash/machinepile{
 	pixel_x = -17
@@ -13028,7 +13027,7 @@
 	pixel_x = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "jdz" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -13068,7 +13067,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "jgb" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -13111,7 +13110,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jjY" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet,
@@ -13125,7 +13124,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "jkW" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -13137,7 +13136,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "jmm" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -13152,7 +13151,7 @@
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "jmO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13191,13 +13190,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "joy" = (
 /obj/structure/wreck/trash/machinepile{
 	pixel_x = -17
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "joN" = (
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -13227,7 +13226,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "jqi" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -13297,7 +13296,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jtN" = (
 /obj/machinery/conveyor/inverted,
 /obj/item/clothing/head/hardhat,
@@ -13350,7 +13349,7 @@
 "jwj" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "jxI" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -13379,7 +13378,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "jzX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -13412,7 +13411,7 @@
 "jBq" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "jBs" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -13445,7 +13444,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "jCb" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced,
@@ -13467,7 +13466,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jCf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -13660,7 +13659,7 @@
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jME" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -13680,18 +13679,18 @@
 "jNJ" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "jNV" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jOl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "jOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
@@ -13759,7 +13758,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jRc" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -13785,11 +13784,11 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "jRP" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "jSN" = (
 /obj/machinery/telecomms/server/presets/khans,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -13811,17 +13810,17 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "jTH" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "jTO" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "jUa" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag{
@@ -13838,11 +13837,11 @@
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "jUp" = (
 /obj/structure/timeddoor,
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
+/area/f13/bunker)
 "jUt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench/crude,
@@ -13873,7 +13872,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jVj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13916,7 +13915,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "jYv" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
@@ -13927,12 +13926,12 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "jYF" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "jZC" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -13944,7 +13943,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "kaa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
@@ -13981,7 +13980,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "kdB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14102,7 +14101,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "kje" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/subway,
@@ -14113,7 +14112,7 @@
 	req_access_txt = "31"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "kjJ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/electropack/shockcollar{
@@ -14151,7 +14150,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "klI" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -14181,7 +14180,7 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/under/f13/vault/v13,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "knd" = (
 /obj/item/storage/trash_stack,
 /obj/item/mine/explosive,
@@ -14288,7 +14287,7 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "ksG" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -14299,7 +14298,7 @@
 "ktc" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "kth" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/machinery/light/small/broken{
@@ -14351,7 +14350,7 @@
 "kuj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "kuo" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -14369,7 +14368,7 @@
 	color = "#363636"
 	},
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "kvc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -14435,7 +14434,7 @@
 /area/f13/building/hospital)
 "kyk" = (
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "kyo" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -14457,7 +14456,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "kzb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -14467,14 +14466,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "kzj" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/waste{
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "kzN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -14524,7 +14523,7 @@
 	pixel_x = -15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "kCP" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
@@ -14563,7 +14562,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "kFa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/folding{
@@ -14651,7 +14650,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "kJd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14727,7 +14726,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "kOh" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14750,7 +14749,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "kPf" = (
 /obj/machinery/light{
 	dir = 1
@@ -14763,11 +14762,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "kQf" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "kQi" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14778,7 +14777,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "kQv" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -14796,7 +14795,7 @@
 "kQJ" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "kQP" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
@@ -14843,7 +14842,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "kSW" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14952,7 +14951,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "kWY" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -14961,7 +14960,7 @@
 /turf/open/floor/f13{
 	icon_state = "damaged3"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "kXe" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -15063,7 +15062,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "kYN" = (
 /obj/structure/fluff/railing,
 /obj/structure/table_frame,
@@ -15076,7 +15075,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "laM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15097,7 +15096,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/f13,
-/area/f13/caves)
+/area/f13/bunker)
 "lbA" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/machinery/light/small/broken{
@@ -15256,7 +15255,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "ljB" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -15276,7 +15275,7 @@
 "lkc" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "lkl" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -15348,7 +15347,7 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "lpx" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -15362,7 +15361,7 @@
 	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "lpJ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -15375,7 +15374,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "lqn" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -15428,7 +15427,7 @@
 /obj/structure/rack,
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "ltE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -15453,7 +15452,7 @@
 	id = "room53"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "lul" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15482,7 +15481,7 @@
 "lwd" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
+/area/f13/bunker)
 "lwe" = (
 /obj/structure/simple_door/metal/ventilation{
 	name = "drainage system"
@@ -15494,7 +15493,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lxm" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15517,7 +15516,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lym" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -15538,7 +15537,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "lzE" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/lattice{
@@ -15547,7 +15546,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lAc" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/dirt,
@@ -15641,7 +15640,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "lDl" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -15651,7 +15650,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "lDK" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -15666,10 +15665,10 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "lDP" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "lEe" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -15710,7 +15709,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "lGi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15758,7 +15757,7 @@
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "lIr" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
@@ -15805,14 +15804,14 @@
 "lJW" = (
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "lKx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "lKP" = (
 /obj/item/flashlight/flare/torch,
 /obj/effect/decal/cleanable/dirt,
@@ -15863,7 +15862,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "lMf" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -15877,7 +15876,7 @@
 "lNn" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "lNx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -15952,7 +15951,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lPN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15961,13 +15960,13 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "lQY" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "lRm" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -15990,7 +15989,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "lRv" = (
 /obj/structure/reagent_dispensers/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -16067,14 +16066,14 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "lTS" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "lUi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13{
@@ -16084,7 +16083,7 @@
 "lUl" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "lUo" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16128,7 +16127,7 @@
 /obj/item/soap,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "lWg" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -16152,7 +16151,7 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "lXf" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -16169,7 +16168,7 @@
 "lXt" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "lXK" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -16180,11 +16179,11 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "lYT" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "lYV" = (
 /obj/structure/chair/folding{
 	dir = 4
@@ -16194,7 +16193,7 @@
 "lZN" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "lZP" = (
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
@@ -16274,12 +16273,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "mcG" = (
 /obj/structure/displaycase,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "mcX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -16302,7 +16301,7 @@
 "mdC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "mdT" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -16330,14 +16329,14 @@
 "mfC" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "mfH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "mfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -16365,7 +16364,7 @@
 /area/f13/tunnel)
 "mgI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "mip" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -16390,12 +16389,12 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mjk" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "mjx" = (
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
@@ -16471,10 +16470,10 @@
 "mmv" = (
 /obj/machinery/computer/security/telescreen,
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
+/area/f13/bunker)
 "mmz" = (
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "mna" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -16531,7 +16530,7 @@
 "mpt" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "mqL" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -16626,7 +16625,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mwO" = (
 /obj/item/radio/intercom{
 	desc = "Is there anyone on the other end? Who's in there?";
@@ -16642,7 +16641,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mxd" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -16652,7 +16651,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mxe" = (
 /obj/machinery/light{
 	dir = 4;
@@ -16720,7 +16719,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mAw" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rain,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16787,7 +16786,7 @@
 /obj/structure/closet/crate/medical/anchored,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "mEb" = (
 /obj/item/instrument/piano_synth,
 /obj/structure/rack,
@@ -16822,12 +16821,12 @@
 "mFJ" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "mHk" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "mIj" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16863,7 +16862,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mIW" = (
 /obj/item/instrument/accordion,
 /obj/structure/rack,
@@ -16896,7 +16895,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/f13,
-/area/f13/caves)
+/area/f13/bunker)
 "mJN" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/indestructible/ground/inside/subway,
@@ -16918,7 +16917,7 @@
 	dir = 9
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "mKr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/raider,
@@ -16949,7 +16948,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/clothing/under/f13/vault/v13,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mLm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/strong,
@@ -16974,14 +16973,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "mMj" = (
 /obj/structure/closet/fridge/meat,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mMT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -17015,7 +17014,7 @@
 "mPJ" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "mQC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17023,7 +17022,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mRk" = (
 /turf/open/floor/f13{
 	icon_state = "darkredfull"
@@ -17051,13 +17050,13 @@
 	},
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "mTh" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "mTT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -17069,7 +17068,7 @@
 	},
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "mUb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17092,7 +17091,7 @@
 "mVd" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mVf" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
 	pixel_x = -3;
@@ -17100,7 +17099,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "mVg" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/glasses/regular,
@@ -17112,7 +17111,7 @@
 "mVK" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "mWn" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/f13vaultrusted,
@@ -17142,7 +17141,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "mXJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -17152,12 +17151,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mXM" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "mXR" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -17170,7 +17169,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "mYn" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17190,7 +17189,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "mZQ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -17204,7 +17203,7 @@
 /obj/item/reagent_containers/food/snacks/burrito,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "naU" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -17249,13 +17248,13 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "ndu" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "ndM" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -17301,7 +17300,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "neS" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -17324,7 +17323,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "ngg" = (
 /obj/structure/barricade/wooden,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -17430,7 +17429,7 @@
 "nlA" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "nlL" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -17496,7 +17495,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "npA" = (
 /obj/structure/spider/cocoon,
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
@@ -17504,7 +17503,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "npK" = (
 /obj/structure/sign/radiation_l,
 /turf/closed/wall/rust,
@@ -17542,7 +17541,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "nrw" = (
 /obj/machinery/button/door{
 	id = "okay";
@@ -17571,7 +17570,7 @@
 	icon_state = "goo10"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "nsc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17580,7 +17579,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "nsm" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -17600,14 +17599,14 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "ntN" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "nuj" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/tunnel{
@@ -17634,7 +17633,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "nvA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17699,16 +17698,16 @@
 "nzq" = (
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "nzs" = (
 /obj/structure/sign/directions/security,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "nzz" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "nzA" = (
 /obj/structure/shelf_wood,
 /obj/item/storage/bag/ore,
@@ -17724,7 +17723,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "nzV" = (
 /obj/structure/chair/sofa/left,
 /mob/living/simple_animal/hostile/centaur,
@@ -17738,14 +17737,14 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "nBE" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "nBU" = (
 /obj/effect/decal/fakelattice,
 /obj/item/shard{
@@ -17757,7 +17756,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "nCh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -17789,7 +17788,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "nDw" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -17824,7 +17823,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "nFk" = (
 /obj/structure/table/booth,
 /obj/effect/decal/waste{
@@ -17923,7 +17922,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "nKR" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -17978,19 +17977,19 @@
 	},
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "nMW" = (
 /obj/machinery/light{
 	dir = 4;
 	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "nMY" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "nND" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -18020,7 +18019,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "nON" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -18077,7 +18076,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "nQo" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -18151,7 +18150,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "nTj" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -18204,20 +18203,20 @@
 "nXl" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "nXm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "nXs" = (
 /obj/item/gps/computer,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "nXt" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13{
@@ -18272,7 +18271,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "nZn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -18434,7 +18433,7 @@
 "ojf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "ojn" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/indestructible/ground/inside/subway,
@@ -18471,7 +18470,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "olq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18483,7 +18482,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "olv" = (
 /obj/structure/shelf_wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
@@ -18578,7 +18577,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "oqm" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -18686,7 +18685,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "ovX" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18718,7 +18717,7 @@
 	},
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "owX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18787,14 +18786,14 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "oBL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/structure/wreck/trash/secway,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "oCq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18812,7 +18811,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "oEi" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -18844,7 +18843,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "oFG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/breathing_masks,
@@ -18872,11 +18871,11 @@
 	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oGu" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "oGV" = (
 /obj/structure/table/wood,
 /obj/structure/railing{
@@ -18900,14 +18899,14 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "oHN" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "oHO" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -18968,7 +18967,7 @@
 "oKm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "oLq" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -19001,15 +19000,15 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "oMy" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "oMP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oMU" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -19050,7 +19049,7 @@
 /obj/structure/rack,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oOm" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
@@ -19058,7 +19057,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "oOp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/large,
@@ -19094,7 +19093,7 @@
 	pixel_x = -15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "oRB" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -19104,7 +19103,7 @@
 	icon_state = "goo8"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "oSc" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
@@ -19130,14 +19129,14 @@
 "oSM" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "oSR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "oTg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19156,7 +19155,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "oUB" = (
 /obj/structure/window/reinforced/spawner,
 /obj/effect/decal/fakelattice,
@@ -19170,7 +19169,7 @@
 	name = "occupied cloning pod"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "oUM" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight,
@@ -19245,7 +19244,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "oXC" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg{
 	pixel_x = 5
@@ -19304,7 +19303,7 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oZr" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull{
@@ -19326,7 +19325,7 @@
 /area/f13/bunker)
 "oZx" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oZA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19335,7 +19334,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "oZK" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -19400,7 +19399,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "pbi" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/three,
@@ -19643,7 +19642,7 @@
 "pnN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "pox" = (
 /obj/structure/showcase/horrific_experiment{
 	desc = "Some sort of pod. Seems this one's maintanance panel is open, someone was working on this.";
@@ -19656,7 +19655,7 @@
 "ppq" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "pqq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -19683,7 +19682,7 @@
 "prT" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "prW" = (
 /mob/living/simple_animal/hostile/radroach,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -19692,7 +19691,7 @@
 "psp" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "psv" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
@@ -19751,7 +19750,7 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pwb" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -19836,7 +19835,7 @@
 "pAi" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19856,7 +19855,7 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "pBn" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19888,7 +19887,7 @@
 	},
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pCC" = (
 /obj/effect/decal/cleanable/chem_pile,
 /obj/effect/turf_decal/weather/dirt{
@@ -19937,7 +19936,7 @@
 "pDW" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pEe" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -20025,7 +20024,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pHL" = (
 /obj/effect/gibspawner/human/bodypartless,
 /turf/open/indestructible/ground/inside/subway{
@@ -20091,7 +20090,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "pLw" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -20117,7 +20116,7 @@
 "pMk" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -20153,7 +20152,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating{
 	name = "plating"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "pOB" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -20162,14 +20161,14 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pOD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "pOT" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/subway,
@@ -20180,7 +20179,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "pPS" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/bio_suit/hazmat,
@@ -20234,7 +20233,7 @@
 "pSm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "pSM" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20247,7 +20246,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pSZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -20282,7 +20281,7 @@
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pVm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20293,14 +20292,14 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pVW" = (
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "pWa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20311,7 +20310,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "pWA" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -20340,7 +20339,7 @@
 	},
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "pYW" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -20380,7 +20379,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qba" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -20397,7 +20396,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qbj" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/cups,
@@ -20426,7 +20425,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qdM" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20442,7 +20441,7 @@
 "qeh" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "qei" = (
 /obj/structure/table,
 /obj/item/radio,
@@ -20488,7 +20487,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "qfx" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -20506,10 +20505,10 @@
 "qgb" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "qgq" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "qgU" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -20525,7 +20524,7 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/plasteel/darkred/side,
-/area/f13/caves)
+/area/f13/bunker)
 "qhm" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhrusty_chess2"
@@ -20546,7 +20545,7 @@
 "qhJ" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "qhN" = (
 /turf/closed/indestructible/f13/matrix/subway{
 	icon_state = "stairs";
@@ -20648,13 +20647,13 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qlL" = (
 /obj/structure/fluff/railing{
 	dir = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "qmg" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -20698,7 +20697,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "qom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -20741,7 +20740,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "qps" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -20819,7 +20818,7 @@
 "qrR" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "qrV" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag{
@@ -20846,7 +20845,7 @@
 /area/f13/tunnel)
 "qsY" = (
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "qtA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -20874,7 +20873,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "qub" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -20925,7 +20924,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "qwk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -20935,7 +20934,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "qwU" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/rust,
@@ -20967,7 +20966,7 @@
 /obj/structure/bed/old,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "qzt" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/rock,
@@ -21038,7 +21037,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "qCG" = (
 /obj/structure/table/wood/settler,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -21051,7 +21050,7 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "qDL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -21129,14 +21128,14 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "qHI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "qHU" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -21183,7 +21182,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "qJn" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/decal/cleanable/dirt,
@@ -21203,7 +21202,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "qKy" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -21272,7 +21271,7 @@
 "qNw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "qNG" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -21322,7 +21321,7 @@
 "qPQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/f13,
-/area/f13/caves)
+/area/f13/bunker)
 "qPV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -21341,11 +21340,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qRk" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "qRw" = (
 /obj/effect/landmark/start/f13/usai,
 /turf/open/floor/f13{
@@ -21374,7 +21373,7 @@
 	name = "occupied cloning pod"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "qTf" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -21382,7 +21381,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qTi" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/dirt,
@@ -21412,7 +21411,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "qTN" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -21468,7 +21467,7 @@
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "qYb" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -21497,7 +21496,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "qZN" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -21544,10 +21543,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rcf" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+/obj/structure/sign/poster/contraband/communist_state{
+	desc = "All hail the Chinese Communist Party!"
 	},
-/area/f13/caves)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "rcv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
@@ -21600,7 +21600,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "reW" = (
 /obj/machinery/light{
 	dir = 1;
@@ -21617,7 +21617,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/hypospray/combat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "rfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -21669,12 +21669,12 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "rjC" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "rjK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -21688,7 +21688,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "rkp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -21720,7 +21720,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "rll" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -21757,7 +21757,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "rph" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21812,7 +21812,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "rro" = (
 /obj/machinery/door/poddoor{
 	id = "soup"
@@ -21825,7 +21825,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "rtc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
@@ -21851,7 +21851,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "rwL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -21906,7 +21906,7 @@
 /area/f13/enclave)
 "ryR" = (
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "rzi" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -22062,7 +22062,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/defibrillator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "rIZ" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/effect/turf_decal/weather/dirt{
@@ -22075,7 +22075,7 @@
 "rJe" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "rJm" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood/settler,
@@ -22154,7 +22154,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "rMI" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -22165,11 +22165,11 @@
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "rMV" = (
 /obj/structure/closet/wardrobe/botanist,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "rMW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/girder/reinforced,
@@ -22201,7 +22201,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "rOk" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor{
@@ -22237,7 +22237,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "rPq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
@@ -22265,7 +22265,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "rRt" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/stripes/red/line{
@@ -22287,7 +22287,7 @@
 "rRS" = (
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "rSu" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -22319,7 +22319,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "rUD" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -22333,7 +22333,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "rUN" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22360,7 +22360,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "rWC" = (
 /obj/structure/closet,
 /obj/item/storage/box/syringes,
@@ -22431,7 +22431,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "sas" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/f13/mre,
@@ -22475,7 +22475,7 @@
 /area/f13/tunnel)
 "sbY" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "scg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
@@ -22498,11 +22498,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "sdo" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "sed" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -22514,7 +22514,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "sel" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22524,7 +22524,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "seI" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/greenglow,
@@ -22627,7 +22627,7 @@
 /obj/structure/chair/office/light,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "sly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -22737,7 +22737,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "ssa" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -22783,21 +22783,21 @@
 	},
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "stA" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "stK" = (
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "stX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -22821,7 +22821,7 @@
 	dir = 1
 	},
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "svj" = (
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22867,7 +22867,7 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "swP" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -22951,7 +22951,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "sAn" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -22972,7 +22972,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "sBw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -23002,7 +23002,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "sCX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23016,7 +23016,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "sDB" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -23062,7 +23062,7 @@
 "sGv" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "sGD" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/effect/decal/remains/human,
@@ -23075,7 +23075,7 @@
 	name = "Dorm 1"
 	},
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "sHE" = (
 /obj/item/lighter/gold,
 /obj/effect/decal/cleanable/dirt,
@@ -23175,7 +23175,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "sOj" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Knight Captain's Office";
@@ -23200,7 +23200,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "sOK" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -23231,7 +23231,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "sQg" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
 	dir = 2;
@@ -23242,7 +23242,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "sQl" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -23303,7 +23303,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "sTj" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -23355,7 +23355,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "sWx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23410,7 +23410,7 @@
 "sZg" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
+/area/f13/bunker)
 "sZh" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stock_parts/cell/ammo/ec,
@@ -23482,7 +23482,7 @@
 	pixel_x = -17
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "tbP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/chem_pile,
@@ -23544,7 +23544,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "tdi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -23588,7 +23588,7 @@
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "tfm" = (
 /obj/structure/table,
 /obj/item/blacksmith/ingot/uranium,
@@ -23663,7 +23663,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "tjs" = (
 /obj/machinery/computer/operating/bos{
 	dir = 1
@@ -23745,7 +23745,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/caves)
+/area/f13/bunker)
 "tnh" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Elders Envoys Office";
@@ -23806,7 +23806,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "tqE" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -23827,7 +23827,7 @@
 /obj/structure/closet,
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "trp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper,
@@ -23848,7 +23848,7 @@
 "ttk" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "ttq" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -23894,7 +23894,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "twd" = (
 /obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23971,7 +23971,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "tzw" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -24030,7 +24030,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "tBR" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24044,7 +24044,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "tCi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24063,7 +24063,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "tDQ" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /obj/structure/chair/f13chair1{
@@ -24080,7 +24080,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "tEd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -24107,7 +24107,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "tEC" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -24122,7 +24122,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/caves)
+/area/f13/bunker)
 "tFN" = (
 /turf/open/floor/plating/dirt,
 /area/f13/tunnel)
@@ -24191,7 +24191,7 @@
 /obj/structure/showcase/machinery/cloning_pod,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "tIu" = (
 /obj/structure/wreck/car/bike,
 /obj/effect/decal/cleanable/dirt,
@@ -24282,7 +24282,7 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "tOx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -24348,7 +24348,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "tSG" = (
 /obj/machinery/power/terminal{
 	dir = 4;
@@ -24405,13 +24405,13 @@
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "tVh" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "tVi" = (
 /obj/effect/decal/waste{
 	pixel_x = -5;
@@ -24491,7 +24491,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "tZo" = (
 /obj/structure/nest/supermutant,
 /obj/effect/decal/cleanable/dirt,
@@ -24512,10 +24512,10 @@
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "uaH" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "uaR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -24530,7 +24530,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "uaV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -24580,7 +24580,7 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "udA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/can,
@@ -24642,7 +24642,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "ugV" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/turf_decal/weather/dirt{
@@ -24679,7 +24679,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "uiP" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -24713,7 +24713,7 @@
 "ukx" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "ukL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -24754,7 +24754,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/caution,
-/area/f13/caves)
+/area/f13/bunker)
 "unZ" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -24778,13 +24778,13 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "upz" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "upT" = (
 /obj/structure/shelf_wood,
 /turf/open/floor/carpet/black,
@@ -24837,7 +24837,7 @@
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "uss" = (
 /obj/machinery/porta_turret/syndicate{
 	faction = list("china")
@@ -24872,7 +24872,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "uuy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -25007,7 +25007,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "uAC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25055,7 +25055,7 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "uBu" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway{
@@ -25084,7 +25084,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "uBY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -25094,7 +25094,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "uCB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25110,7 +25110,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "uDo" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25172,7 +25172,7 @@
 "uFd" = (
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "uFt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -25185,7 +25185,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "uFO" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -25214,7 +25214,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "uHK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/museum)
@@ -25226,7 +25226,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "uIB" = (
 /obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt,
@@ -25303,7 +25303,7 @@
 	id = "room52"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "uLz" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
@@ -25334,14 +25334,14 @@
 /obj/item/bedsheet/blue,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "uPp" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "uPP" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
@@ -25371,13 +25371,13 @@
 /obj/structure/rack,
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/darkred/side,
-/area/f13/caves)
+/area/f13/bunker)
 "uSn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "uSx" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/midsurgery,
@@ -25398,13 +25398,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "uUU" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "uUZ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -25467,7 +25467,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "uXj" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
@@ -25483,7 +25483,7 @@
 "uYm" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "uYT" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/f13{
@@ -25520,7 +25520,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 10
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vbm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25531,14 +25531,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "vbw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "vbJ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -25698,7 +25698,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vha" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -25707,7 +25707,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "vhf" = (
 /obj/structure/closet{
 	storage_capacity = 10
@@ -25855,7 +25855,7 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/caves)
+/area/f13/bunker)
 "vom" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -25868,7 +25868,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "von" = (
 /obj/machinery/light{
 	dir = 4;
@@ -25900,7 +25900,7 @@
 "vpx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "vqu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25908,7 +25908,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "vqO" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -25952,7 +25952,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/area/f13/bunker)
 "vrz" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -25963,10 +25963,10 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vsj" = (
 /turf/open/floor/plasteel/caution,
-/area/f13/caves)
+/area/f13/bunker)
 "vsH" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25987,7 +25987,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "vts" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -26091,7 +26091,7 @@
 "vzW" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "vBc" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -26149,18 +26149,18 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "vCG" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "vCM" = (
 /obj/structure/bed/pod,
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "vDJ" = (
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "vEk" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/crafting/abraxo,
@@ -26168,7 +26168,7 @@
 	layer = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "vEA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -26230,7 +26230,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vJN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -26342,7 +26342,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vNy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26350,7 +26350,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "vNL" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -26369,7 +26369,7 @@
 "vOB" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "vOF" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/f13{
@@ -26495,13 +26495,13 @@
 "vVY" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "vWd" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "vWu" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/box/ration/menu_eight,
@@ -26618,7 +26618,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "vZb" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -26668,7 +26668,7 @@
 "waP" = (
 /obj/structure/cross,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "wbT" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -26683,7 +26683,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wcF" = (
 /obj/item/stack/sheet/bone,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26700,7 +26700,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "wer" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Junker Deserter"
@@ -26715,7 +26715,7 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/f13,
-/area/f13/caves)
+/area/f13/bunker)
 "wft" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -26750,7 +26750,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wgq" = (
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26777,7 +26777,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wiw" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3";
@@ -26801,7 +26801,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "wiW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -26818,7 +26818,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "wjU" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/subway{
@@ -26856,7 +26856,7 @@
 	name = "Dorm 1"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "wmM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26867,7 +26867,7 @@
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wmX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -26913,7 +26913,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "wpP" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
@@ -26940,7 +26940,7 @@
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "wqv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -27044,7 +27044,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wwo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular{
@@ -27056,7 +27056,7 @@
 "wws" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "wwt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27108,12 +27108,12 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "wzI" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/bunker)
 "wzU" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -27158,12 +27158,12 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "wBb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "wBt" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -27216,7 +27216,7 @@
 /obj/structure/table/wood,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "wCz" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -27284,7 +27284,7 @@
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "wEW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -27318,7 +27318,7 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
+/area/f13/bunker)
 "wIj" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/spacevine{
@@ -27364,7 +27364,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "wKV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -27435,7 +27435,7 @@
 "wPI" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "wPN" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -27443,7 +27443,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "wQf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -27492,7 +27492,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "wTf" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/effect/decal/cleanable/dirt,
@@ -27532,7 +27532,7 @@
 "wVq" = (
 /obj/structure/dresser,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "wVM" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/centaur,
@@ -27545,7 +27545,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "wXc" = (
 /obj/machinery/conveyor/inverted,
 /obj/structure/closet/crate/wooden,
@@ -27562,12 +27562,12 @@
 "wXr" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "wXt" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "wXM" = (
 /obj/structure/table{
 	layer = 2.9
@@ -27599,7 +27599,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
+/area/f13/bunker)
 "wYJ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -27704,7 +27704,7 @@
 	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "xeh" = (
 /obj/structure/girder/reinforced,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27713,11 +27713,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/caution,
-/area/f13/caves)
+/area/f13/bunker)
 "xeD" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "xfk" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/greenglow,
@@ -27786,7 +27786,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xiq" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -27796,7 +27796,7 @@
 /obj/structure/table/glass,
 /obj/structure/fluff/railing,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
+/area/f13/bunker)
 "xiY" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -27818,7 +27818,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xkB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -27855,7 +27855,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "xms" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/subway{
@@ -27901,7 +27901,7 @@
 	icon_state = "goo8"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "xpI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -27913,7 +27913,7 @@
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
-/area/f13/caves)
+/area/f13/bunker)
 "xqr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -27946,7 +27946,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xrd" = (
 /obj/structure/stairs/north,
 /turf/open/indestructible/ground/inside/subway,
@@ -27960,13 +27960,13 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "xsE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "xsT" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/waste{
@@ -27977,7 +27977,7 @@
 "xur" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xuN" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -27989,7 +27989,7 @@
 "xuR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "xvz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -28012,7 +28012,7 @@
 	icon_state = "goo10"
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "xwF" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
@@ -28026,7 +28026,7 @@
 	},
 /obj/structure/bed/old,
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "xxC" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -28040,7 +28040,7 @@
 	},
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xxJ" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -28077,7 +28077,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xzy" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28095,9 +28095,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xAc" = (
-/obj/effect/decal/fakelattice,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/bunker)
 "xAo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28116,7 +28116,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "xBe" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -28184,7 +28184,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xFf" = (
 /obj/structure/decoration/clock,
 /turf/closed/wall/r_wall/rust,
@@ -28213,7 +28213,7 @@
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xFT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -28308,7 +28308,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
+/area/f13/bunker)
 "xKm" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28322,7 +28322,7 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xKV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -28335,7 +28335,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "xLb" = (
 /turf/open/floor/f13{
 	icon_state = "redmark"
@@ -28358,12 +28358,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xMl" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/river,
-/area/f13/caves)
+/area/f13/bunker)
 "xMw" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -28412,7 +28412,7 @@
 "xOD" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xOM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -28431,12 +28431,12 @@
 "xPa" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
+/area/f13/bunker)
 "xPj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/caves)
+/area/f13/bunker)
 "xPS" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -28470,7 +28470,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xQO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -28502,7 +28502,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "xSd" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -28538,7 +28538,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/floor/plasteel,
-/area/f13/caves)
+/area/f13/bunker)
 "xSA" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -28563,7 +28563,7 @@
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xTX" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28623,7 +28623,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/area/f13/bunker)
 "xWc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28631,7 +28631,7 @@
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
+/area/f13/bunker)
 "xWj" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -28646,7 +28646,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "xWy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/radroach,
@@ -28688,10 +28688,8 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "xXu" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/bunker)
 "xXv" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -28746,7 +28744,7 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
+/area/f13/bunker)
 "xZu" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorybasement";
@@ -28885,7 +28883,7 @@
 /obj/structure/table,
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
+/area/f13/bunker)
 "yih" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28914,7 +28912,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
-/area/f13/caves)
+/area/f13/bunker)
 "yiX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
@@ -28945,7 +28943,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/f13/caves)
+/area/f13/bunker)
 "yjO" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -29000,7 +28998,7 @@
 /obj/item/trash/sosjerky,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/area/f13/bunker)
 "ylU" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -64974,12 +64972,12 @@ aae
 aae
 aae
 aaa
-bCG
+aaj
 mmv
 mmv
 rjC
-bCG
-bCG
+aaj
+aaj
 aaa
 aae
 aae
@@ -65231,12 +65229,12 @@ aae
 aae
 aae
 aaa
-tmV
+rcf
 eKs
 mjg
-bOr
+nzz
 eay
-bCG
+aaj
 aaa
 aae
 aae
@@ -65488,12 +65486,12 @@ aae
 aae
 aae
 aaa
-bCG
+aaj
 yio
 hKX
 hKX
 tcY
-bCG
+aaj
 aaa
 aae
 aae
@@ -65745,12 +65743,12 @@ aae
 aae
 aae
 aaa
-bCG
+aaj
 qbc
 esN
 bzP
 dgz
-bCG
+aaj
 aaa
 aae
 aae
@@ -66002,12 +66000,12 @@ aae
 aae
 aae
 aaa
-tmV
+rcf
 nXs
 nvw
 mwO
 npw
-bCG
+aaj
 aaa
 aae
 aae
@@ -66259,12 +66257,12 @@ aae
 aae
 aae
 aaa
-bCG
-bCG
-bCG
+aaj
+aaj
+aaj
 jUp
-bCG
-bCG
+aaj
+aaj
 aaa
 aae
 aae
@@ -80733,7 +80731,7 @@ fap
 iCK
 vDJ
 vDJ
-cQH
+iYN
 iCK
 fap
 aaa
@@ -80987,10 +80985,10 @@ xwF
 aaa
 fap
 cHs
-xAc
-rcf
+bie
+aEe
 fdz
-cQH
+iYN
 jnN
 fap
 aaa
@@ -81247,8 +81245,8 @@ jUU
 urK
 btd
 nBU
-cQH
-xXu
+iYN
+aLC
 fap
 aaa
 xwF
@@ -81264,7 +81262,7 @@ dnc
 dnc
 uAf
 mMj
-vyO
+bBR
 fap
 aaa
 xwF
@@ -81500,11 +81498,11 @@ xwF
 xwF
 aaa
 fap
-rcf
+aEe
 axD
 vDJ
 mQC
-cQH
+iYN
 jnN
 fap
 aaa
@@ -81519,8 +81517,8 @@ aaa
 fap
 vsc
 whX
-vyO
-vyO
+bBR
+bBR
 xzk
 htW
 aaa
@@ -82016,9 +82014,9 @@ aaa
 fap
 fap
 fap
-cQH
+iYN
 iQE
-nYi
+xAc
 fap
 fap
 aaa
@@ -82038,7 +82036,7 @@ rQW
 cDA
 ukx
 kQf
-abV
+gjm
 isv
 fap
 fap
@@ -82275,7 +82273,7 @@ gJu
 rNT
 qeh
 fXl
-cQH
+iYN
 fap
 aaa
 aaa
@@ -82294,7 +82292,7 @@ xsE
 cWV
 xsE
 vDJ
-cQH
+iYN
 ksq
 hdC
 bHT
@@ -82531,8 +82529,8 @@ fap
 fon
 fXl
 fXl
-cQH
-cQH
+iYN
+iYN
 fap
 aaa
 fap
@@ -82551,7 +82549,7 @@ xsE
 oZx
 xsE
 gmM
-iYN
+aEl
 neK
 btl
 bHT
@@ -84344,7 +84342,7 @@ iZw
 tSi
 kyZ
 vDJ
-rcf
+aEe
 pUS
 caR
 iQG
@@ -84856,7 +84854,7 @@ aaa
 aaa
 fap
 lZN
-rcf
+aEe
 jwj
 uSn
 hSt
@@ -85906,8 +85904,8 @@ ojf
 xsE
 lPN
 bHT
-xwF
-xwF
+xXu
+xXu
 bHT
 ikT
 wVq
@@ -86163,8 +86161,8 @@ qZv
 weh
 nSZ
 bHT
-xwF
-xwF
+xXu
+xXu
 bHT
 qoc
 hWD
@@ -86420,8 +86418,8 @@ ojf
 xsE
 mxd
 bHT
-xwF
-xwF
+xXu
+xXu
 xFw
 qyT
 vDJ
@@ -86944,7 +86942,7 @@ mVd
 oZx
 xsE
 bHT
-xwF
+xXu
 fap
 mmz
 qNw
@@ -87177,7 +87175,7 @@ qRk
 lYT
 pOx
 fap
-xwF
+xXu
 fap
 lGc
 fap
@@ -87434,7 +87432,7 @@ mcG
 lYT
 hGb
 fap
-xwF
+xXu
 fap
 fXU
 fap
@@ -87691,7 +87689,7 @@ eDO
 lYT
 vDJ
 fap
-xwF
+xXu
 iZw
 owV
 fXU
@@ -87705,7 +87703,7 @@ guJ
 xsE
 mxd
 bHT
-xwF
+xXu
 hGb
 sbY
 sbY
@@ -87948,7 +87946,7 @@ eDO
 fap
 eAl
 fap
-xwF
+xXu
 fap
 iZw
 iZw
@@ -87962,7 +87960,7 @@ weh
 nKJ
 xlS
 bHT
-xwF
+xXu
 lGc
 bHT
 fap
@@ -88205,10 +88203,10 @@ xur
 fap
 eAl
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 lYT
 hHr
 xkj
@@ -88219,7 +88217,7 @@ oZx
 oZx
 oZx
 bHT
-xwF
+xXu
 fXU
 bHT
 scQ
@@ -88462,10 +88460,10 @@ fTx
 lYT
 ePW
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 lYT
 khN
 xFw
@@ -88719,10 +88717,10 @@ xur
 fap
 xYP
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 fap
 lKx
 hsb
@@ -88976,10 +88974,10 @@ oUq
 lYT
 hQc
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 fap
 eAl
 fap
@@ -89233,21 +89231,21 @@ pWn
 bbV
 ePW
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 fap
 qgb
 fap
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
 gio
 lwd
-xwF
-bIg
-bIg
+xXu
+gHs
+gHs
 vDJ
 lYT
 wBb
@@ -89490,15 +89488,15 @@ oMs
 bbV
 sbY
 fap
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
 iZw
 jNJ
 fap
-xwF
-xwF
+xXu
+xXu
 lwd
 gio
 uFd
@@ -89754,13 +89752,13 @@ fap
 fap
 jNJ
 fap
-xwF
-xwF
+xXu
+xXu
 npA
 gio
 wzI
-aaB
-aaB
+aul
+aul
 lYT
 sbY
 fap
@@ -90004,20 +90002,20 @@ ntN
 fap
 sbY
 sbY
-nzz
-nzz
-nzz
-nzz
+aOd
+aOd
+aOd
+aOd
 sbY
 vDJ
 fap
-xwF
-xwF
+xXu
+xXu
 lNn
 mVf
-adz
+ahd
 nzq
-aaB
+aul
 lYT
 vDJ
 fap
@@ -90262,19 +90260,19 @@ fap
 jNV
 fap
 fap
-nzz
+aOd
 fap
 fap
 fap
 fap
 fap
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
 lHm
 iul
-xwF
-xwF
+xXu
+xXu
 lYT
 vDJ
 fap
@@ -90515,20 +90513,20 @@ hsb
 fap
 ppq
 hhU
-xXu
+aLC
 eDO
 jYF
 lYT
 sbY
 fap
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
 lwd
 lwd
 lwd
@@ -90795,7 +90793,7 @@ fap
 gHo
 mLS
 hCT
-rcf
+aEe
 vDJ
 bwl
 aFk
@@ -91053,8 +91051,8 @@ kuQ
 kuQ
 wcc
 vDJ
-iYN
-iYN
+aEl
+aEl
 tDX
 aFk
 fap
@@ -91311,7 +91309,7 @@ wcc
 eAl
 vDJ
 lPw
-iYN
+aEl
 tDX
 jRC
 lDP
@@ -91549,15 +91547,15 @@ jYj
 iZw
 sbY
 fap
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
 fap
 vEk
 das
@@ -91806,15 +91804,15 @@ eAl
 fap
 jNJ
 fap
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
+xXu
 fap
 bwl
 hZN
@@ -91823,7 +91821,7 @@ fap
 wBb
 lDP
 uYm
-cQH
+iYN
 wws
 wws
 jTO
@@ -92080,7 +92078,7 @@ fap
 fap
 sdo
 sdo
-cQH
+iYN
 lDP
 lDP
 lYS
@@ -92829,7 +92827,7 @@ vDJ
 lpE
 lpE
 vgN
-cQH
+iYN
 iZw
 lYT
 eAj
@@ -93088,7 +93086,7 @@ pSm
 etm
 dbR
 jNJ
-xXu
+aLC
 sbY
 fap
 aaa
@@ -93599,7 +93597,7 @@ kQJ
 qgq
 vOB
 bHT
-cQH
+iYN
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
+++ b/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
@@ -5266,9 +5266,6 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"awC" = (
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood)
 "awD" = (
 /obj/effect/spawner/lootdrop/high_tools,
 /turf/open/floor/plasteel/f13{
@@ -8365,7 +8362,7 @@
 "aHc" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "aHd" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old,
@@ -23199,7 +23196,7 @@
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "dWS" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23713,7 +23710,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ejg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin/trash_fallout,
@@ -27459,7 +27456,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "fKP" = (
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -27592,7 +27589,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "fOB" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -30374,7 +30371,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "gYX" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
@@ -32672,7 +32669,7 @@
 /obj/item/clothing/head/helmet/knight/constable,
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ieF" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -33499,7 +33496,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iwD" = (
 /obj/structure/displaycase,
 /obj/item/clothing/accessory/necklace,
@@ -33742,7 +33739,7 @@
 /obj/item/clothing/suit/armor/heavy/riot/knight/tabard,
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iAR" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -34175,7 +34172,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iIm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -39856,7 +39853,7 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "llo" = (
 /obj/structure/simple_door/room{
 	name = "Sergeant Room"
@@ -43397,7 +43394,7 @@
 /obj/item/melee/coyote/oldhalberd,
 /obj/item/melee/coyote/oldhalberd,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "mJQ" = (
 /obj/structure/blacksmith/anvil/obtainable/legion,
 /obj/effect/decal/cleanable/dirt,
@@ -44221,7 +44218,7 @@
 	req_access_txt = "281"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nco" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spacevine,
@@ -44370,7 +44367,7 @@
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nfd" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/f13/ruins,
@@ -45813,7 +45810,7 @@
 "nLG" = (
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nLN" = (
 /obj/machinery/light{
 	dir = 1
@@ -49605,7 +49602,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "psD" = (
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt{
@@ -52943,7 +52940,7 @@
 "qST" = (
 /obj/structure/stairs/north,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "qTj" = (
 /obj/structure/flora/tree/jungle/small,
 /mob/living/simple_animal/hostile/bloatfly,
@@ -53236,7 +53233,7 @@
 "qZQ" = (
 /obj/structure/closet/crate/bin/trash_fallout,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "qZR" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -54213,7 +54210,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "rBs" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/junglebush,
@@ -55641,7 +55638,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "shX" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -55786,10 +55783,6 @@
 /obj/item/toy/cards/deck/unum,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building)
-"slb" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "sld" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/dirt,
@@ -56235,7 +56228,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "stD" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -58144,10 +58137,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/firestation)
-"trR" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "trZ" = (
 /obj/structure/decoration/legion/chains,
 /obj/structure/railing/handrail/legion/end,
@@ -66080,7 +66069,7 @@
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "wTN" = (
 /obj/machinery/light{
 	dir = 1
@@ -66977,9 +66966,6 @@
 	name = "tile"
 	},
 /area/f13/building)
-"xqa" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "xqf" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -68140,7 +68126,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "xPJ" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -69045,7 +69031,7 @@
 "ykv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ykA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/gravel_edge{
@@ -69111,7 +69097,7 @@
 "ylm" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ylw" = (
 /obj/structure/flora/grass/coyote/eighteen,
 /turf/open/indestructible/ground/outside/desert,
@@ -89831,18 +89817,18 @@ vxc
 aOk
 aky
 aky
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
 kls
 eDQ
 itu
@@ -90087,19 +90073,19 @@ aky
 aky
 aky
 aky
-awC
-awC
+xvy
+xvy
 nLG
 psq
 fOr
 nLG
 psq
-awC
+xvy
 neS
 xPH
 dWF
-awC
-awC
+xvy
+xvy
 aky
 oBE
 oBE
@@ -90344,19 +90330,19 @@ woD
 woD
 woD
 woD
-awC
+xvy
 ylm
-xqa
-xqa
-xqa
-xqa
-xqa
-awC
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
+xvy
+jeh
+jeh
+jeh
 ieA
-awC
+xvy
 aky
 vuk
 vuk
@@ -90601,19 +90587,19 @@ dkx
 oYF
 eJO
 woD
-awC
+xvy
 ykv
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 nce
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
 iAH
-awC
+xvy
 aky
 vuk
 vuk
@@ -90858,19 +90844,19 @@ oYF
 oYF
 oYF
 woD
-awC
+xvy
 qST
 aHc
-awC
+xvy
 nce
-awC
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+xvy
+jeh
+jeh
 wTb
-awC
-awC
+xvy
+xvy
 aky
 gOT
 nGf
@@ -91115,19 +91101,19 @@ oYF
 oYF
 eJO
 woD
-awC
+xvy
 qST
-xqa
-awC
-xqa
+jeh
+xvy
+jeh
 fKE
-slb
-awC
-xqa
-xqa
+qHy
+xvy
+jeh
+jeh
 mJH
-awC
-awC
+xvy
+xvy
 pvg
 bcB
 nww
@@ -91372,18 +91358,18 @@ oYF
 oYF
 oYF
 woD
-awC
-awC
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+xvy
+xvy
+jeh
+jeh
 iwn
-awC
-xqa
-xqa
-xqa
-awC
+xvy
+jeh
+jeh
+jeh
+xvy
 xvy
 xUb
 bcB
@@ -91629,18 +91615,18 @@ aAV
 oYF
 eJO
 woD
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
 nce
 ejf
 rBr
-awC
-awC
+xvy
+xvy
 iIj
 shW
-awC
+xvy
 geW
 pvg
 bcB
@@ -91888,16 +91874,16 @@ woD
 woD
 wea
 wea
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+jeh
+jeh
 stC
 qZQ
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
 wea
 pLf
 nhy
@@ -92146,15 +92132,15 @@ wea
 wea
 wea
 wea
-awC
+xvy
 gYE
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 llk
-awC
+xvy
 geW
 kZO
 pvg
@@ -92403,15 +92389,15 @@ ilL
 dDO
 mDx
 wea
-awC
+xvy
 qST
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 ylm
-awC
+xvy
 oHF
 wkP
 iGc
@@ -92660,15 +92646,15 @@ gLt
 wea
 ahY
 wea
-awC
-awC
-trR
-awC
-trR
-awC
-awC
-awC
-awC
+xvy
+xvy
+sAz
+xvy
+sAz
+xvy
+xvy
+xvy
+xvy
 aSN
 aCu
 eOO

--- a/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
+++ b/_maps/map_files/Pahrump-AB/Pahrump-AB.dmm
@@ -5266,9 +5266,6 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"awC" = (
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood)
 "awD" = (
 /obj/effect/spawner/lootdrop/high_tools,
 /turf/open/floor/plasteel/f13{
@@ -8365,7 +8362,7 @@
 "aHc" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "aHd" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old,
@@ -23205,7 +23202,7 @@
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "dWQ" = (
 /turf/open/indestructible/ground/inside/dirt/stamped/outside,
 /area/f13/caves)
@@ -23722,7 +23719,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ejg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin/trash_fallout,
@@ -26560,10 +26557,6 @@
 	icon_state = "desertcracked3"
 	},
 /area/f13/wasteland)
-"frW" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "fsg" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -27468,7 +27461,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "fKP" = (
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -27601,7 +27594,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "fOB" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -29861,7 +29854,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "gND" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/outside/dirt{
@@ -30383,7 +30376,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "gYX" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
@@ -31571,11 +31564,6 @@
 	icon_state = "desertsmooth4"
 	},
 /area/f13/wasteland)
-"hCd" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "hCe" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken1"
@@ -32681,7 +32669,7 @@
 /obj/item/clothing/head/helmet/knight/constable,
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ieF" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -33508,7 +33496,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iwD" = (
 /obj/structure/displaycase,
 /obj/item/clothing/accessory/necklace,
@@ -33751,7 +33739,7 @@
 /obj/item/clothing/suit/armor/heavy/riot/knight/tabard,
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iAR" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -34184,7 +34172,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "iIm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -34304,10 +34292,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/coyote/twenty,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"iLv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
 /area/f13/wasteland)
 "iLw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35256,7 +35240,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "jfB" = (
 /turf/closed/wall/r_wall,
 /area/f13/wasteland)
@@ -35361,10 +35345,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top"
 	},
-/area/f13/wasteland)
-"jhV" = (
-/obj/structure/spacevine,
-/turf/closed/wall/f13/wood,
 /area/f13/wasteland)
 "jif" = (
 /obj/machinery/power/terminal{
@@ -36203,10 +36183,6 @@
 /turf/open/indestructible/ground/outside/desert/sonora/rough{
 	icon_state = "desertcracked4"
 	},
-/area/f13/wasteland)
-"jBy" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "jBG" = (
 /obj/structure/tires/two,
@@ -39865,7 +39841,7 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "llo" = (
 /obj/structure/simple_door/room{
 	name = "Sergeant Room"
@@ -43406,7 +43382,7 @@
 /obj/item/melee/coyote/oldhalberd,
 /obj/item/melee/coyote/oldhalberd,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "mJQ" = (
 /obj/structure/blacksmith/anvil/obtainable/legion,
 /obj/effect/decal/cleanable/dirt,
@@ -44230,7 +44206,7 @@
 	req_access_txt = "281"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nco" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spacevine,
@@ -44379,7 +44355,7 @@
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nfd" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/f13/ruins,
@@ -45822,7 +45798,7 @@
 "nLG" = (
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "nLN" = (
 /obj/machinery/light{
 	dir = 1
@@ -49614,7 +49590,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "psD" = (
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt{
@@ -49804,11 +49780,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pvF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine,
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
 "pvH" = (
 /obj/structure/barricade/tentleatheredge{
 	dir = 4
@@ -52952,7 +52923,7 @@
 "qST" = (
 /obj/structure/stairs/north,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "qTj" = (
 /obj/structure/flora/tree/jungle/small,
 /mob/living/simple_animal/hostile/bloatfly,
@@ -53245,7 +53216,7 @@
 "qZQ" = (
 /obj/structure/closet/crate/bin/trash_fallout,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "qZR" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -54222,7 +54193,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "rBs" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/junglebush,
@@ -55650,7 +55621,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "shX" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -55795,10 +55766,6 @@
 /obj/item/toy/cards/deck/unum,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building)
-"slb" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "sld" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/dirt,
@@ -56244,7 +56211,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "stD" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -58159,10 +58126,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/firestation)
-"trR" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "trZ" = (
 /obj/structure/decoration/legion/chains,
 /obj/structure/railing/handrail/legion/end,
@@ -61135,7 +61098,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "uGr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -61625,9 +61588,6 @@
 	color = "#e4e4e4"
 	},
 /area/f13/legion)
-"uQr" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
 "uQs" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -61937,11 +61897,6 @@
 /turf/open/indestructible/ground/outside/desert/sonora/rough{
 	icon_state = "desertcracked4"
 	},
-/area/f13/wasteland)
-"uWW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
 /area/f13/wasteland)
 "uWY" = (
 /obj/structure/table/wood/settler,
@@ -66095,7 +66050,7 @@
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "wTN" = (
 /obj/machinery/light{
 	dir = 1
@@ -66992,9 +66947,6 @@
 	name = "tile"
 	},
 /area/f13/building)
-"xqa" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "xqf" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -68155,7 +68107,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "xPJ" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -68900,7 +68852,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "ygZ" = (
 /obj/effect/turf_decal/gravel_edge/corner,
 /turf/open/indestructible/ground/outside/dirt,
@@ -69060,7 +69012,7 @@
 "ykv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ykA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/gravel_edge{
@@ -69126,7 +69078,7 @@
 "ylm" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/f13/wood,
-/area/f13/brotherhood)
+/area/f13/city)
 "ylw" = (
 /obj/structure/flora/grass/coyote/eighteen,
 /turf/open/indestructible/ground/outside/desert,
@@ -89846,18 +89798,18 @@ vxc
 aOk
 aky
 aky
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
+xvy
 kls
 eDQ
 itu
@@ -90102,19 +90054,19 @@ aky
 aky
 aky
 aky
-awC
-awC
+xvy
+xvy
 nLG
 psq
 fOr
 nLG
 psq
-awC
+xvy
 neS
 xPH
 dWF
-awC
-awC
+xvy
+xvy
 aky
 oBE
 oBE
@@ -90359,19 +90311,19 @@ woD
 woD
 woD
 woD
-awC
+xvy
 ylm
-xqa
-xqa
-xqa
-xqa
-xqa
-awC
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
+xvy
+jeh
+jeh
+jeh
 ieA
-awC
+xvy
 aky
 vuk
 vuk
@@ -90616,19 +90568,19 @@ dkx
 oYF
 eJO
 woD
-awC
+xvy
 ykv
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 nce
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
 iAH
-awC
+xvy
 aky
 vuk
 vuk
@@ -90873,19 +90825,19 @@ oYF
 oYF
 oYF
 woD
-awC
+xvy
 qST
 aHc
-awC
+xvy
 nce
-awC
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+xvy
+jeh
+jeh
 wTb
-awC
-awC
+xvy
+xvy
 aky
 gOT
 nGf
@@ -91130,19 +91082,19 @@ oYF
 oYF
 eJO
 woD
-awC
+xvy
 qST
-xqa
-awC
-xqa
+jeh
+xvy
+jeh
 fKE
-slb
-awC
-xqa
-xqa
+qHy
+xvy
+jeh
+jeh
 mJH
-awC
-awC
+xvy
+xvy
 pvg
 bcB
 nww
@@ -91387,18 +91339,18 @@ oYF
 oYF
 oYF
 woD
-awC
-awC
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+xvy
+xvy
+jeh
+jeh
 iwn
-awC
-xqa
-xqa
-xqa
-awC
+xvy
+jeh
+jeh
+jeh
+xvy
 xvy
 xUb
 bcB
@@ -91644,18 +91596,18 @@ aAV
 oYF
 eJO
 woD
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
 nce
 ejf
 rBr
-awC
-awC
+xvy
+xvy
 iIj
 shW
-awC
+xvy
 geW
 pvg
 bcB
@@ -91903,16 +91855,16 @@ woD
 woD
 wea
 wea
-awC
-awC
-xqa
-xqa
+xvy
+xvy
+jeh
+jeh
 stC
 qZQ
-awC
-awC
-awC
-awC
+xvy
+xvy
+xvy
+xvy
 wea
 pLf
 nhy
@@ -92161,15 +92113,15 @@ wea
 wea
 wea
 wea
-awC
+xvy
 gYE
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 llk
-awC
+xvy
 geW
 kZO
 pvg
@@ -92418,15 +92370,15 @@ ilL
 dDO
 mDx
 wea
-awC
+xvy
 qST
-xqa
-xqa
-xqa
-xqa
-xqa
+jeh
+jeh
+jeh
+jeh
+jeh
 ylm
-awC
+xvy
 oHF
 wkP
 iGc
@@ -92675,15 +92627,15 @@ gLt
 wea
 ahY
 wea
-awC
-awC
-trR
-awC
-trR
-awC
-awC
-awC
-awC
+xvy
+xvy
+sAz
+xvy
+sAz
+xvy
+xvy
+xvy
+xvy
 aSN
 aCu
 eOO
@@ -97893,10 +97845,10 @@ xLC
 iCs
 lVj
 iCs
-jhV
+hHX
 uGl
-jBy
-jhV
+pgO
+hHX
 amN
 rbF
 odm
@@ -98150,7 +98102,7 @@ lVj
 lVj
 xLC
 xLC
-pvF
+blQ
 ygX
 jfp
 gNx
@@ -98407,10 +98359,10 @@ jxM
 jxM
 jxM
 eHw
-uQr
-frW
-hCd
-jhV
+acl
+rOp
+bdQ
+hHX
 xLC
 xLC
 sYy
@@ -98664,10 +98616,10 @@ amN
 amN
 sYy
 xLC
-uQr
-uWW
-iLv
-iLv
+acl
+meb
+abu
+abu
 odm
 hFC
 gOG


### PR DESCRIPTION
## About The Pull Request
This PR is mainly a fixing the areas in most dungeons instead of all of them being all cave areas or any others. 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: area alligment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
