### PR TITLE
Fix CI integration tests crashing due to MySQL 8 caching_sha2_password auth

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -164,6 +164,7 @@ jobs:
       - name: Setup database
         run: |
           sudo systemctl start mysql
+          mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           mysql -u root -proot -e 'CREATE DATABASE tg_ci;'
           mysql -u root -proot tg_ci < SQL/tgstation_schema.sql
           mysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'


### PR DESCRIPTION
## About The Pull Request
The `run_all_tests` job was panicking inside rust-g's mysql_common crate:

  thread '<unnamed>' panicked at 'mask too long',
  mysql_common-0.30.5/src/crypto/rsa.rs:83:13

This happens because MySQL 8 defaults to `caching_sha2_password`, which uses RSA-OAEP key exchange. The version of mysql_common bundled with rust-g 3.0.0 has a bug where it panics if the RSA key is too large.

Fix: switch the root user to `mysql_native_password` before creating test databases, bypassing RSA entirely.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
server: Fixed integration tests panicking due to MySQL 8 caching_sha2_password RSA issue by switching to mysql_native_password.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
