### PR TITLE
Lockpicking Minigame

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -198,6 +198,7 @@
 #define TRAIT_NO_MIDROUND_ANTAG	"no-midround-antag" //can't be turned into an antag by random events
 #define TRAIT_PUGILIST	"pugilist" //This guy punches people for a living
 #define TRAIT_KI_VAMPIRE	"ki-vampire" //when someone with this trait rolls maximum damage on a punch and stuns the target, they regain some stamina and do clone damage
+#define TRAIT_LOCKPICKING	"lockpicking_skilled" // Professional muscle memory: wider zones, quieter work, more timer grace
 #define TRAIT_ASSASSIN	"assassin" //Can perform deadly assassination strikes on unaware enemies
 #define TRAIT_PASSTABLE			"passtable"
 #define TRAIT_GIANT				"giant"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -118,6 +118,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return destination
 
 /proc/getline(atom/M,atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
+	if(!M || !N)
+		return list()
 	var/px=M.x		//starting x
 	var/py=M.y
 	var/line[] = list(locate(px,py,M.z))

--- a/code/datums/components/crafting/recipes/recipes_tools.dm
+++ b/code/datums/components/crafting/recipes/recipes_tools.dm
@@ -142,8 +142,8 @@
 /datum/crafting_recipe/lock_tier5
 	name = "Master Security Lock"
 	result = /obj/item/lock_construct/tier5
-	time = 200
-	reqs = list(/obj/item/stack/sheet/metal = 6, /obj/item/stack/rods = 5, /obj/item/stack/crafting/metalparts = 3)
+	time = 220
+	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/rods = 3, /obj/item/stack/crafting/metalparts = 2, /obj/item/advanced_crafting_components/alloys = 2)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL
@@ -160,8 +160,8 @@
 /datum/crafting_recipe/lockpick_master
 	name = "Master Lockpick Set"
 	result = /obj/item/lockpick_set/master
-	time = 150
-	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/crafting/metalparts = 4)
+	time = 180
+	reqs = list(/obj/item/stack/sheet/metal = 3, /obj/item/stack/crafting/metalparts = 2, /obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL

--- a/code/datums/components/crafting/recipes/recipes_tools.dm
+++ b/code/datums/components/crafting/recipes/recipes_tools.dm
@@ -148,6 +148,51 @@
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL
 
+/datum/crafting_recipe/lock_tier2
+	name = "Standard Lock"
+	result = /obj/item/lock_construct/tier2
+	time = 90
+	reqs = list(/obj/item/stack/sheet/metal = 2, /obj/item/stack/rods = 1)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lockpick_master
+	name = "Master Lockpick Set"
+	result = /obj/item/lockpick_set/master
+	time = 120
+	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/crafting/metalparts = 2)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lockpick_tension
+	name = "Tension Wrench Kit"
+	result = /obj/item/lockpick_set/tension_wrench
+	time = 100
+	reqs = list(/obj/item/stack/sheet/metal = 4, /obj/item/stack/rods = 2)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lockpick_bobby
+	name = "Bobby Pin"
+	result = /obj/item/lockpick_set/bobby_pin
+	time = 30
+	reqs = list(/obj/item/stack/sheet/metal = 1)
+	tools = list()
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lockpick_electronic
+	name = "Electronic Lock Pick"
+	result = /obj/item/lockpick_set/electronic_pick
+	time = 160
+	reqs = list(/obj/item/stack/sheet/metal = 3, /obj/item/stack/crafting/metalparts = 3, /obj/item/stock_parts/cell = 1)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
 /datum/crafting_recipe/msreloader
 	name = "Makeshift Reloading Press"
 	result = /obj/item/circuitboard/machine/autolathe/ammo/improvised

--- a/code/datums/components/crafting/recipes/recipes_tools.dm
+++ b/code/datums/components/crafting/recipes/recipes_tools.dm
@@ -121,6 +121,33 @@
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL
 
+/datum/crafting_recipe/lock_tier3
+	name = "Reinforced Lock"
+	result = /obj/item/lock_construct/tier3
+	time = 100
+	reqs = list(/obj/item/stack/sheet/metal = 3, /obj/item/stack/rods = 2)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lock_tier4
+	name = "Security Lock"
+	result = /obj/item/lock_construct/tier4
+	time = 140
+	reqs = list(/obj/item/stack/sheet/metal = 4, /obj/item/stack/rods = 3, /obj/item/stack/crafting/metalparts = 1)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
+/datum/crafting_recipe/lock_tier5
+	name = "Master Security Lock"
+	result = /obj/item/lock_construct/tier5
+	time = 180
+	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/rods = 4, /obj/item/stack/crafting/metalparts = 2)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_CRAFTING
+	subcategory = CAT_TOOL
+
 /datum/crafting_recipe/msreloader
 	name = "Makeshift Reloading Press"
 	result = /obj/item/circuitboard/machine/autolathe/ammo/improvised

--- a/code/datums/components/crafting/recipes/recipes_tools.dm
+++ b/code/datums/components/crafting/recipes/recipes_tools.dm
@@ -142,8 +142,8 @@
 /datum/crafting_recipe/lock_tier5
 	name = "Master Security Lock"
 	result = /obj/item/lock_construct/tier5
-	time = 180
-	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/rods = 4, /obj/item/stack/crafting/metalparts = 2)
+	time = 200
+	reqs = list(/obj/item/stack/sheet/metal = 6, /obj/item/stack/rods = 5, /obj/item/stack/crafting/metalparts = 3)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL
@@ -160,8 +160,8 @@
 /datum/crafting_recipe/lockpick_master
 	name = "Master Lockpick Set"
 	result = /obj/item/lockpick_set/master
-	time = 120
-	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/crafting/metalparts = 2)
+	time = 150
+	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/crafting/metalparts = 4)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL
@@ -187,8 +187,8 @@
 /datum/crafting_recipe/lockpick_electronic
 	name = "Electronic Lock Pick"
 	result = /obj/item/lockpick_set/electronic_pick
-	time = 160
-	reqs = list(/obj/item/stack/sheet/metal = 3, /obj/item/stack/crafting/metalparts = 3, /obj/item/stock_parts/cell = 1)
+	time = 180
+	reqs = list(/obj/item/stack/sheet/metal = 3, /obj/item/stack/crafting/metalparts = 4, /obj/item/stock_parts/cell/high = 1)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_CRAFTING
 	subcategory = CAT_TOOL

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1267,6 +1267,17 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/japanese)
 
+/datum/quirk/locksmith
+	name = "Locksmith"
+	desc = "Years of practice with tumblers and tension wrenches have given you a professional edge. \
+			Lockpicking zones feel wider, your hands are quieter, and your instincts for lock anatomy are sharper."
+	value = 4
+	mob_trait = TRAIT_LOCKPICKING
+	gain_text = span_notice("Your fingers remember a hundred locks. Every cylinder has a story.")
+	lose_text = span_danger("Your feel for tumblers fades — just another amateur with a bent wire.")
+	medical_record_text = "Patient demonstrates fine motor skill consistent with professional locksmithing experience."
+	locked = FALSE
+
 /datum/quirk/assassin
 	name = "Assassin"
 	desc = "Years of practice have made you lethal at close range. While sneaking with a melee weapon in your active hand, you can assassinate unaware enemies within 2 tiles by attacking from behind."

--- a/code/game/atoms_movement.dm
+++ b/code/game/atoms_movement.dm
@@ -10,9 +10,6 @@
 	if(!newloc || newloc == loc)
 		return
 
-	if(anchored)
-		return
-
 	if(!direction)
 		direction = get_dir(src, newloc)
 

--- a/code/game/atoms_movement.dm
+++ b/code/game/atoms_movement.dm
@@ -10,6 +10,9 @@
 	if(!newloc || newloc == loc)
 		return
 
+	if(anchored)
+		return
+
 	if(!direction)
 		direction = get_dir(src, newloc)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -39,6 +39,10 @@
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	var/proj_resist = 10
+	/// Lock difficulty for lockpicking mini-game (1 = very easy, 5 = very hard)
+	var/lock_tier = 2
+	/// Set TRUE when a lockpick snap or exhausted attempts jams the mechanism.
+	var/lockpick_jammed = FALSE
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -157,85 +161,53 @@
 /obj/machinery/door/proc/try_to_lockpick(obj/item/lockpick_set/picking, mob/user)
 	if(!istype(picking))
 		return FALSE
+	if(lockpick_jammed)
+		to_chat(user, span_warning("The lock is jammed solid. Use a crowbar to reset the mechanism first."))
+		return FALSE
+	if(picking.in_use)
+		to_chat(user, span_warning("Your lockpick is already in use."))
+		return FALSE
 
 	picking.in_use = TRUE
 
-	var/list/pick_messages = list(
-		"otherpicking" = list(
-			"[user] starts to pick a lock!",
-			"[user] begins picking a lock!",
-			"[user] begins to jimmy a lock!",
-			"[user] begins to try and open a lock!"
-		),
-		"mepicking" = list(
-			"You slide your tools into the lock...",
-			"You begin trying to jimmy the lock...",
-			"You begin raking the tumblers...",
-			"This lock shouldn't take much longer..."
-		),
-		"blindpicking" = list(
-			"Is that metal clicking?",
-			"Is someone tapping metal together?",
-			"You hear an odd mechanical picking and scraping sound.",
-			"That's an odd metal noise..."
-		),
-		"failmessages" = list(
-			"Wrist slipped... try again...",
-			"Almost got it...",
-			"One more tumbler...",
-			"Come on...",
-			"Anytime now..."
-		),
-		"successmessages" = list(
-			"Got it!",
-			"Phew!",
-			"Easy!",
-			"Done!"
-		)
+	var/list/start_messages_other = list(
+		"[user] starts to pick a lock!",
+		"[user] begins picking a lock!",
+		"[user] begins to jimmy a lock!"
+	)
+	var/list/start_messages_self = list(
+		"You slide your tools into the lock...",
+		"You begin trying to jimmy the lock...",
+		"You begin raking the tumblers..."
+	)
+	var/list/start_messages_blind = list(
+		"Is that metal clicking?",
+		"Is someone tapping metal together?",
+		"You hear an odd mechanical picking and scraping sound."
 	)
 
 	user.visible_message(
-		pick(pick_messages["otherpicking"]),
-		pick(pick_messages["mepicking"]),
-		pick(pick_messages["blindpicking"])
-		)
-	playsound(
-		get_turf(src),
-		pick('sound/items/screwdriver.ogg','sound/items/screwdriver2.ogg'),
-		25,
-		1,
-		ignore_walls = FALSE
-		)
+		pick(start_messages_other),
+		pick(start_messages_self),
+		pick(start_messages_blind)
+	)
+	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
 
-	if(!do_after(user, 4 SECONDS, target = src))
-		user.show_message(span_alert(pick(pick_messages["failmessages"])))
-		playsound(
-			get_turf(src),
-			pick('sound/items/screwdriver.ogg','sound/items/screwdriver2.ogg'),
-			25,
-			1,
-			ignore_walls = FALSE
-			)
-		picking.in_use = FALSE
-		picking.use_pick(user)
-		return
+	// Start the interactive mini-game
+	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier)
+	game.wait()
 
-	playsound(
-		get_turf(src),
-		pick('sound/items/screwdriver.ogg','sound/items/screwdriver2.ogg'),
-		25,
-		1,
-		ignore_walls = FALSE
-		)
-	
-	if(prob(15))
-		user.show_message(span_green(pick(pick_messages["successmessages"])))
+	var/success = game.result
+	game.finalize(user)
+	if(!QDELETED(game))
+		qdel(game)
+
+	if(success)
+		user.show_message(span_green("You feel the lock give way. It's open!"))
 		try_to_activate_door(user, TRUE)
 		. = TRUE
-	else
-		user.show_message(span_alert(pick(pick_messages["failmessages"])))
-	picking.in_use = FALSE
-	picking.use_pick(user)
+	else if(lockpick_jammed)
+		to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it."))
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user, force_open)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -202,7 +202,7 @@
 		pick(start_messages_self),
 		pick(start_messages_blind)
 	)
-	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
+	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 18, TRUE, -10)
 
 	// Pass src as lock_ref so the pin combination stays consistent across attempts.
 	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier, src)
@@ -231,7 +231,7 @@
 				span_notice("You start working the pins back into position..."),
 				span_notice("You hear a careful series of soft clicks from [src].")
 			)
-			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 50, TRUE, ignore_walls = FALSE)
+			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 35, TRUE, -10)
 			if(!do_after(user, 50, target = src))
 				return FALSE
 			if(QDELETED(src))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -45,6 +45,8 @@
 	var/lockpick_jammed = FALSE
 	/// Set TRUE after a successful lockpick; cleared when an authorized user re-closes the door.
 	var/tampered = FALSE
+	/// Transient flag: set by try_to_lockpick before opening so do_animate can muffle the door-open sound.
+	var/lockpick_muffled = FALSE
 	/// Stored pin solution — ensures the same combination each time this door is lockpicked.
 	var/list/pin_solution = null
 	/// Stored binding order for pin solution persistence.
@@ -219,7 +221,9 @@
 		tampered = TRUE
 		pin_solution   = null
 		pin_bind_order = null
+		lockpick_muffled = TRUE   // muffle the door-open sound — a skilled lockpick is quiet
 		try_to_activate_door(user, TRUE)
+		lockpick_muffled = FALSE  // safety reset in case open() didn't consume it
 		. = TRUE
 	else
 		// After a failed attempt the pins must walk back to resting position before

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -40,9 +40,11 @@
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	var/proj_resist = 10
 	/// Lock difficulty for lockpicking mini-game (1 = very easy, 5 = very hard)
-	var/lock_tier = 2
+	var/lock_tier = 5
 	/// Set TRUE when a lockpick snap or exhausted attempts jams the mechanism.
 	var/lockpick_jammed = FALSE
+	/// Set TRUE after a successful lockpick; cleared when an authorized user re-closes the door.
+	var/tampered = FALSE
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -53,6 +55,8 @@
 			. += span_notice("In the event of a red alert, its access requirements will automatically lift.")
 	if(!poddoor)
 		. += "<span class='notice'>Its maintenance panel is <b>screwed</b> in place.</span>"
+	if(tampered)
+		. += span_warning("The lock looks like it's been worked — someone forced their way through.")
 
 /obj/machinery/door/check_access_list(list/access_list)
 	if(red_alert_access && GLOB.security_level >= SEC_LEVEL_RED)
@@ -140,11 +144,14 @@
 	if(operating)
 		return
 	src.add_fingerprint(user)
+	var/mob/original_user = user
 	if(!src.requiresID())
 		user = null
 
 	if(density && !(obj_flags & EMAGGED))
 		if(allowed(user))
+			if(tampered && original_user)
+				to_chat(original_user, span_warning("The lock looks like it's been worked \u2014 someone forced their way through."))
 			open()
 		else
 			do_animate("deny")
@@ -204,6 +211,7 @@
 
 	if(success)
 		user.show_message(span_green("You feel the lock give way. It's open!"))
+		tampered = TRUE
 		try_to_activate_door(user, TRUE)
 		. = TRUE
 	else if(lockpick_jammed)
@@ -217,8 +225,22 @@
 		user = null //so allowed(user) always succeeds
 	if(allowed(user) || force_open)
 		if(density)
+			if(tampered && !force_open && user)
+				to_chat(user, span_warning("The lock looks like it's been worked \u2014 someone forced their way through."))
 			open()
 		else
+			if(!force_open && tampered && user)
+				user.visible_message(
+					span_notice("[user] starts re-securing [src]'s lock."),
+					span_notice("You start re-securing the lock..."),
+					span_notice("You hear careful metallic clicking from [src].")
+				)
+				if(!do_after(user, 20, target = src))
+					return TRUE
+				if(QDELETED(src))
+					return TRUE
+				to_chat(user, span_notice("You re-secure the lock."))
+				tampered = FALSE
 			close()
 		return TRUE
 	if(density)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -45,6 +45,10 @@
 	var/lockpick_jammed = FALSE
 	/// Set TRUE after a successful lockpick; cleared when an authorized user re-closes the door.
 	var/tampered = FALSE
+	/// Stored pin solution — ensures the same combination each time this door is lockpicked.
+	var/list/pin_solution = null
+	/// Stored binding order for pin solution persistence.
+	var/list/pin_bind_order = null
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -200,11 +204,12 @@
 	)
 	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
 
-	// Start the interactive mini-game
-	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier)
+	// Pass src as lock_ref so the pin combination stays consistent across attempts.
+	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier, src)
 	game.wait()
 
 	var/success = game.result
+	var/gave_up = game.gave_up
 	game.finalize(user)
 	if(!QDELETED(game))
 		qdel(game)
@@ -212,10 +217,31 @@
 	if(success)
 		user.show_message(span_green("You feel the lock give way. It's open!"))
 		tampered = TRUE
+		pin_solution   = null
+		pin_bind_order = null
 		try_to_activate_door(user, TRUE)
 		. = TRUE
-	else if(lockpick_jammed)
-		to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it."))
+	else
+		// After a failed attempt the pins must walk back to resting position before
+		// a new attempt can begin (mirrors simple_door pry-off behaviour).
+		// Voluntary give-up withdraws cleanly — no reset needed.
+		if(!QDELETED(src) && !lockpick_jammed && !gave_up)
+			user.visible_message(
+				span_notice("[user] starts working the pins in [src]'s lock back into position."),
+				span_notice("You start working the pins back into position..."),
+				span_notice("You hear a careful series of soft clicks from [src].")
+			)
+			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 50, TRUE, ignore_walls = FALSE)
+			if(!do_after(user, 50, target = src))
+				return FALSE
+			if(QDELETED(src))
+				return FALSE
+			user.visible_message(
+				span_notice("[user] finishes resetting [src]'s lock mechanism."),
+				span_notice("The mechanism is reset. Try again.")
+			)
+		if(lockpick_jammed)
+			to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it."))
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user, force_open)
 	add_fingerprint(user)
@@ -241,6 +267,8 @@
 					return TRUE
 				to_chat(user, span_notice("You re-secure the lock."))
 				tampered = FALSE
+				pin_solution   = null
+				pin_bind_order = null
 			close()
 		return TRUE
 	if(density)
@@ -260,6 +288,22 @@
 	return
 
 /obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
+	if(lockpick_jammed)
+		user.visible_message(
+			span_notice("[user] starts working [src]'s jammed lock mechanism loose."),
+			span_notice("You start working the jammed mechanism loose..."),
+			span_notice("You hear a grinding scrape of metal from [src].")
+		)
+		playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 60, TRUE, ignore_walls = FALSE)
+		if(!do_after(user, 35, target = src))
+			return
+		if(QDELETED(src))
+			return
+		lockpick_jammed = FALSE
+		user.visible_message(
+			span_notice("[user] pries the jammed lock mechanism loose on [src]."),
+			span_notice("You pry the jammed mechanism loose — the lock resets.")
+		)
 	return
 
 /obj/machinery/door/proc/is_holding_pressure()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -294,8 +294,9 @@
 			span_notice("You start working the jammed mechanism loose..."),
 			span_notice("You hear a grinding scrape of metal from [src].")
 		)
-		playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 60, TRUE, ignore_walls = FALSE)
-		if(!do_after(user, 35, target = src))
+		if(!istype(I, /obj/item/crowbar/power))
+			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 60, TRUE, ignore_walls = FALSE)
+		if(!do_after(user, 35 * I.toolspeed, target = src))
 			return
 		if(QDELETED(src))
 			return

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -157,8 +157,11 @@
 	else
 		icon_state = "open"
 
-/obj/machinery/door/poddoor/try_to_activate_door(mob/user)
-	return
+/obj/machinery/door/poddoor/try_to_activate_door(mob/user, force_open)
+	if(force_open && density)
+		open()
+		return TRUE
+	// Poddoors don't respond to manual bumping — use a linked button
 
 /obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
 	if(stat & NOPOWER)

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -18,6 +18,8 @@
 /obj/machinery/door/unpowered/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/lockpick_set))
 		return ..()  // always forward lockpicks to the parent's try_to_lockpick dispatch
+	if(I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/twohanded/fireaxe))
+		return ..()  // always forward crowbars so try_to_crowbar works even on locked/jammed doors
 	if(locked)
 		return
 	else

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -16,6 +16,8 @@
 	return
 
 /obj/machinery/door/unpowered/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/lockpick_set))
+		return ..()  // always forward lockpicks to the parent's try_to_lockpick dispatch
 	if(locked)
 		return
 	else

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -34,6 +34,7 @@
 	assemblytype = /obj/item/stack/sheet/mineral/wood/five
 	opacity = TRUE
 	explosion_block = TRUE
+	lock_tier = 3
 
 /obj/machinery/door/unpowered/securedoor/update_icon()
 	if(density)
@@ -56,16 +57,19 @@
 /obj/machinery/door/unpowered/securedoor/legion
 	name = "Legion Castrum"
 	req_access_txt = "123"
+	lock_tier = 5
 
 //khoor
 /obj/machinery/door/unpowered/securedoor/khandoor
 	name = "khan door"
 	req_access_txt = "125"
+	lock_tier = 4
 
 //bikoor
 /obj/machinery/door/unpowered/securedoor/bikerdoor
 	name = "Hell's Nomad door"
 	req_access = list(ACCESS_BIKER)
+	lock_tier = 4
 
 
 // ------------------------------------
@@ -108,6 +112,7 @@
 	max_integrity = 1000
 	obj_integrity = 1000
 	explosion_block = TRUE
+	lock_tier = 3
 
 /obj/machinery/door/unpowered/secure_steeldoor/update_icon()
 	if(density)
@@ -139,6 +144,7 @@
 	explosion_block = FALSE
 	pass_flags = LETPASSTHROW  // would be great but the var is not functional for some reason.
 	proj_pass_rate = 95
+	lock_tier = 3
 
 /obj/machinery/door/unpowered/celldoor/update_icon()
 	if(density)
@@ -177,6 +183,7 @@
 	explosion_block = FALSE
 	proj_pass_rate = 95
 	req_access_txt = "123"
+	lock_tier = 3
 
 /obj/machinery/door/unpowered/secure_legion/update_icon()
 	if(density)

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -272,6 +272,9 @@
 	return ..()
 
 /datum/effect_system/smoke_spread/chem/set_up(datum/reagents/carry = null, radius = 1, loca, silent = FALSE)
+	if(!istype(carry, /datum/reagents))
+		stack_trace("smoke_spread/chem/set_up called with invalid reagents (got [carry])")
+		return
 	if(isturf(loca))
 		location = loca
 	else

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1896,6 +1896,8 @@
 				/obj/effect/decal/cleanable/oil/slippery, //oh dear
 				/obj/effect/gibspawner/human,
 				/obj/effect/gibspawner/generic/animal,
+				/obj/item/lockpick_set,
+				/obj/item/lockpick_set/bobby_pin,
 				)
 
 /obj/effect/spawner/lootdrop/f13/seedspawner

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2359,7 +2359,7 @@
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
-				/obj/item/book/granter/trait/lockpicking = 5,
+				/obj/item/book/granter/trait/lockpicking = 3,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four = 10,
 //				/obj/item/book/granter/crafting_recipe/gunsmith_five = 5
@@ -2377,7 +2377,7 @@
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
-				/obj/item/book/granter/trait/lockpicking = 5,
+				/obj/item/book/granter/trait/lockpicking = 3,
 				/obj/item/book/granter/crafting_recipe/gunsmith_two = 20,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four = 10,)

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2357,6 +2357,7 @@
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
+				/obj/item/book/granter/trait/lockpicking = 5,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four = 10,
 //				/obj/item/book/granter/crafting_recipe/gunsmith_five = 5
@@ -2374,6 +2375,7 @@
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
+				/obj/item/book/granter/trait/lockpicking = 5,
 				/obj/item/book/granter/crafting_recipe/gunsmith_two = 20,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three = 10,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four = 10,)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -101,6 +101,22 @@
 	icon_state = "book1"
 	remarks = list("One smooth motion...", "Palm the bolt...", "Push up, rotate back, push forward, down...", "Don't slap yourself with the bolt...", "Wait, what's this about pumping?", "Who just scribbled \"Z\" and \"LMB\" on this page?")
 
+/obj/item/book/granter/trait/lockpicking
+	name = "Confidential: The Art of the Open Door"
+	desc = "A slim, dog-eared manual with no author listed. Chapters cover pin-tumbler theory, tension control, and reading binding order by feel. Someone has underlined the words 'patience' and 'don\'t rush' in every chapter."
+	oneuse = TRUE
+	granted_trait = TRAIT_LOCKPICKING
+	traitname = "lockpicking"
+	icon_state = "book2"
+	remarks = list(
+		"Single-pin picking: apply light tension, find the binding pin...",
+		"The binding pin is the one the cylinder is pressing on hardest...",
+		"Set it, move to the next. Don\'t rush — the cylinder remembers...",
+		"False sets feel almost right. Trust the feedback, not the click...",
+		"If it jams, you pushed too fast. The pick is now your enemy...",
+		"The last pin drops and something clicks. That\'s the feeling."
+	)
+
 ///ACTION BUTTONS///
 
 /obj/item/book/granter/action

--- a/code/game/objects/items/lock.dm
+++ b/code/game/objects/items/lock.dm
@@ -6,13 +6,70 @@ GLOBAL_LIST_EMPTY(global_locks)
 	var/lock_data
 	var/static/lock_uid = 1
 	var/locked = FALSE
+	/// Lock difficulty for lockpicking mini-game (1 = trivial, 5 = master-security).
+	var/lock_tier = 1
 	var/prying = FALSE //if somebody is trying to pry us off
+	/// Set TRUE when the lock is bypassed by lockpicking — cleared when re-locked with a key.
+	var/tampered = FALSE
+	/// Stored tumbler solution — per-pin min/max/type/false-zone/stack-height.
+	/// Generated on the first lockpick attempt and reused on all subsequent ones
+	/// so the lock has a consistent combination. Cleared on successful pick.
+	var/list/pin_solution = null
+	/// Stored binding order for the pin solution.
+	var/list/pin_bind_order = null
+	/// world.time after which a new pick attempt may begin.
+	/// Set after every non-success ending to impose a mechanism-reset delay.
+	var/pick_reset_until = 0
 
-/obj/item/lock_construct/Initialize() // Same system machines use for UID. Could probably add a global UID for everything if you wanted and use it for shenanigans, or simpler loading.
+/obj/item/lock_construct/Initialize()
 	. = ..()
 	lock_data = lock_uid++
-	desc = "A heavy-duty lock for doors. It has [lock_data] engraved on it."
+	desc = "A basic lock for doors. It has [lock_data] engraved on it."
 	GLOB.global_locks += src
+
+/obj/item/lock_construct/examine(mob/user)
+	. = ..()
+	switch(lock_tier)
+		if(1) . += span_notice("The mechanism is simple — basic tumbler, easy to pick.")
+		if(2) . += span_notice("The mechanism looks sturdy — standard quality.")
+		if(3) . += span_notice("The mechanism looks heavy-duty — reinforced internals.")
+		if(4) . += span_notice("The mechanism is complex — security-grade pins.")
+		if(5) . += span_notice("The mechanism looks formidable — master-security grade.")
+
+// Tier subtypes — each has a distinct name, description, and lock_tier.
+// Tier 1 is the base type. Tiers 2–5 are crafted at a workbench.
+
+/obj/item/lock_construct/tier2
+	name = "\improper standard lock"
+	lock_tier = 2
+
+/obj/item/lock_construct/tier2/Initialize()
+	. = ..()
+	desc = "A well-made standard lock. It has [lock_data] engraved on it."
+
+/obj/item/lock_construct/tier3
+	name = "\improper reinforced lock"
+	lock_tier = 3
+
+/obj/item/lock_construct/tier3/Initialize()
+	. = ..()
+	desc = "A reinforced lock with hardened internals. It has [lock_data] engraved on it."
+
+/obj/item/lock_construct/tier4
+	name = "\improper security lock"
+	lock_tier = 4
+
+/obj/item/lock_construct/tier4/Initialize()
+	. = ..()
+	desc = "A security-grade lock with precision-machined pins. It has [lock_data] engraved on it."
+
+/obj/item/lock_construct/tier5
+	name = "\improper master security lock"
+	lock_tier = 5
+
+/obj/item/lock_construct/tier5/Initialize()
+	. = ..()
+	desc = "A formidable vault-quality lock. Almost nothing short of a master pick will open this. It has [lock_data] engraved on it."
 
 /obj/item/lock_construct/Destroy()
 	..()
@@ -44,6 +101,7 @@ GLOBAL_LIST_EMPTY(global_locks)
 		else
 			user.visible_message(span_warning("[user] locks \the [src]."))
 			locked = TRUE
+			tampered = FALSE  // faction member re-locked it — tampering acknowledged
 	else
 		to_chat(user, span_warning("This is the wrong key!"))
 

--- a/code/game/objects/items/prize_loot.dm
+++ b/code/game/objects/items/prize_loot.dm
@@ -49,6 +49,8 @@
 	var/trapped = FALSE
 	//whether its locked or not, will allow it to either open or not
 	var/locked = TRUE
+	/// Set TRUE when a lockpick snap or exhausted attempts jams the mechanism.
+	var/lockpick_jammed = FALSE
 	//so you can't spam click the locked crate
 	var/used = FALSE
 	//this will just add whatever is here right before locked crate
@@ -115,6 +117,13 @@
 	qdel(src) //NO MORE, YOU MUST DIE AFTER SPAWNING
 
 /obj/item/locked_box/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/crowbar))
+		if(lockpick_jammed)
+			lockpick_jammed = FALSE
+			to_chat(user, span_notice("You pry the mechanism loose — the lock resets. You can try picking it again."))
+			playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, TRUE)
+			return TRUE
+		return ..() // normal crowbar behavior if not jammed
 	if(istype(W, /obj/item/screwdriver))
 		if(!locked)
 			return
@@ -131,15 +140,29 @@
 		locked = FALSE
 		return
 	else if(istype(W, /obj/item/lockpick_set))
+		var/obj/item/lockpick_set/the_pick = W
 		if(!locked)
 			return
-		var/success_after_tier = max(100 - (lock_tier * 20), 0) //the higher the lock tier, the harder it is, down to a max of 0
-		var/success_after_skill = min((user.client.prefs.special_l * 5) + success_after_tier, 100) //the higher the persons luck, the better, up to a max of 100, with 50 added
-		if(!prob(success_after_skill))
-			to_chat(user, span_warning("You fail to pick [src]."))
+		if(lockpick_jammed)
+			to_chat(user, span_warning("[src]'s lock is jammed solid. Use a crowbar to reset the mechanism first."))
 			return
-		to_chat(user, span_green("You successfully unlock [src]."))
-		locked = FALSE
+		if(the_pick.in_use)
+			to_chat(user, span_warning("The lockpick is already in use."))
+			return
+		the_pick.in_use = TRUE
+		var/datum/lockpicking_minigame/game = new(src, user, the_pick, lock_tier)
+		game.wait()
+		var/success = game.result
+		game.finalize(user)
+		if(!QDELETED(game))
+			qdel(game)
+		if(QDELETED(src))
+			return
+		if(success)
+			to_chat(user, span_green("You successfully unlock [src]."))
+			locked = FALSE
+		else if(lockpick_jammed)
+			to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it before trying again."))
 		return
 	else
 		return ..()

--- a/code/game/objects/items/prize_loot.dm
+++ b/code/game/objects/items/prize_loot.dm
@@ -153,6 +153,7 @@
 		var/datum/lockpicking_minigame/game = new(src, user, the_pick, lock_tier)
 		game.wait()
 		var/success = game.result
+		var/gave_up = game.gave_up
 		game.finalize(user)
 		if(!QDELETED(game))
 			qdel(game)
@@ -161,8 +162,16 @@
 		if(success)
 			to_chat(user, span_green("You successfully unlock [src]."))
 			locked = FALSE
-		else if(lockpick_jammed)
-			to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it before trying again."))
+		else
+			if(!QDELETED(src) && !lockpick_jammed && !gave_up)
+				to_chat(user, span_notice("You work the pins back to their resting position."))
+				if(!do_after(user, 30, target = src))
+					return
+				if(QDELETED(src))
+					return
+				to_chat(user, span_notice("The mechanism is reset. You can try again."))
+			if(lockpick_jammed)
+				to_chat(user, span_warning("The lock jammed! Use a crowbar to reset it before trying again."))
 		return
 	else
 		return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -33,7 +33,10 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal arrowhead", /obj/item/stack/arrowhead/metal, 2, 1, time = 2.5 SECONDS), \
 	new/datum/stack_recipe("field arrowhead", /obj/item/stack/arrowhead/field, 1, 1, time = 1 SECONDS), \
 	null, \
-	new/datum/stack_recipe("lock", /obj/item/lock_construct, 1), \
+	new/datum/stack_recipe_list("locks", list(
+		new/datum/stack_recipe("basic lock", /obj/item/lock_construct, 1),
+		new/datum/stack_recipe("standard lock", /obj/item/lock_construct/tier2, 2),
+	)), \
 	new/datum/stack_recipe("coffee pot", /obj/item/crafting/coffee_pot, 1), \
 	new/datum/stack_recipe("lunchbox", /obj/item/crafting/lunchbox, 1), \
 	new/datum/stack_recipe("key", /obj/item/key, 1), \

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -310,14 +310,19 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	RegisterSignal(user, COMSIG_MOB_ATTACK_HAND, PROC_REF(on_user_hit))
 	RegisterSignal(user, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_user_hit))
 
-	// Overhead icon so bystanders can see the player is lockpicking.
-	// Alpha scales with picker skill: high perception+agility = subtler (lower alpha).
-	// mouse_opacity = 0 makes the overlay non-interactive — BYOND passes clicks
-	// through it to the tile below, so observers standing nearby aren't bumped north.
-	pick_overlay = mutable_appearance('icons/mob/actions/actions_flightsuit.dmi', "flightsuit_lock")
+	// Overhead icon above the picker — bystanders see who is working the lock.
+	// TILE_BOUND clamps the overlay's interactive area to the picker's tile so clicks
+	// on the portion extending above the head don't register as the northern tile
+	// (same technique used by the sneak indicator).
+	// Alpha scales with picker skill: clumsy pickers fidget visibly; skilled pickers
+	// move with precision and draw less attention.
+	// Range: alpha 180 (low skill, clearly visible) to 60 (max skill, subtle but seeable).
+	// ABOVE_MOB_LAYER as third arg ensures the overlay renders above the mob sprite.
+	pick_overlay = mutable_appearance('icons/mob/actions/actions_flightsuit.dmi', "flightsuit_lock", ABOVE_MOB_LAYER)
 	pick_overlay.pixel_y = 28
-	pick_overlay.mouse_opacity = 0
-	pick_overlay.alpha = clamp(240 - (perception + agility - 2) * 15, 20, 240)
+	pick_overlay.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	pick_overlay.appearance_flags = RESET_COLOR | PIXEL_SCALE
+	pick_overlay.alpha = clamp(190 - (perception + agility - 2) * 7, 60, 190)
 	var/matrix/M = matrix()
 	M.Scale(0.55)
 	pick_overlay.transform = M
@@ -1194,10 +1199,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	// Sneaking (walk intent) makes the picker's movements quieter — the sounds are
 	// physically softer, so the effective range AND detail level drop for observers.
 	var/sneak_penalty = (isliving(user) && user:m_intent == MOVE_INTENT_WALK) ? 3 : 0
-	// Extended range: high-perception observers (7+) can pick out subtle sounds from
-	// further away. Past 4 tiles requires at least perception 7 just to catch anything.
-	// Sneaking shrinks the broadcast radius to 5 tiles.
-	var/broadcast_range = sneak_penalty ? 5 : 8
+	// Successful pin sets (the pin quietly drops into the shear line) are the
+	// QUIETEST moment — no spring-back, no scrape. Only close observers catch it.
+	// Failed sets (spring-back scraping) carry further; Joseph's longer-range
+	// awareness reward applies to those, not to the subtle success click.
+	var/broadcast_range = was_set ? 4 : (sneak_penalty ? 5 : 8)
+	var/far_threshold   = was_set ? 2 : (sneak_penalty ? 2 : 4)
 	for(var/mob/M in view(broadcast_range, T))
 		if(M == user)
 			continue
@@ -1207,9 +1214,6 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		if(obs_perc <= 0)
 			continue
 		var/obs_dist = get_dist(M, T)
-		// Past 4 tiles only perception 7+ can catch anything — the sound is too faint.
-		// When the picker is sneaking, that threshold tightens to 2 tiles.
-		var/far_threshold = sneak_penalty ? 2 : 4
 		if(obs_dist > far_threshold && obs_perc < 7)
 			continue
 		// Distance penalty: each tile beyond 2 costs 2 effective perception.

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -133,14 +133,37 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/feedback = ""
 	/// null = in progress, TRUE = success, FALSE = fail/cancel
 	var/result = null
+	/// Set to TRUE when the player voluntarily gives up (vs. actual failure)
+	var/gave_up = FALSE
 	/// Whether the user was anchored before lockpicking began (restored on Destroy)
 	var/was_anchored = FALSE
+	/// Noise emitted per failed set attempt: 0=silent, 1=quiet, 2=loud, 3=jangling
+	var/pick_noise_level = 1
+	/// Accumulated noise tally — resets to 0 after alerting nearby listeners
+	var/accumulated_noise = 0
+	/// world.time when the minigame began (for tension-fatigue timer)
+	var/timer_start = 0
+	/// Total timer duration in ticks (0 = no timer; only tier 3+ locks)
+	var/timer_duration = 0
+	/// TRUE once the 30-second cramp warning has been issued
+	var/timer_warning_sent = FALSE
+	/// Whether the user has TRAIT_LOCKPICKING
+	var/has_lockpick_trait = FALSE
+	/// Shuffled list of pin indices determining binding order for this lock
+	var/list/bind_order = null
+	/// uses_left when the pick was first inserted (baseline for wear calculation)
+	var/pick_initial_uses = 0
+	/// Reference to the physical lock object — used to persist pin solution
+	var/obj/item/lock_construct/the_lock = null
+	/// Overhead icon overlay displayed above the user's mob while picking
+	var/mutable_appearance/pick_overlay = null
 
-/datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier)
+/datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier, obj/item/lock_construct/lock_ref = null)
 	target    = the_target
 	user      = the_user
 	pick      = the_pick
 	lock_tier = clamp(tier, 1, 5)
+	the_lock  = lock_ref
 	luck      = the_user.special_l
 	if(isliving(the_user))
 		agility    = the_user.special_a
@@ -163,6 +186,23 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	is_bobby_pin       = istype(the_pick, /obj/item/lockpick_set/bobby_pin)
 	is_electronic_pick = istype(the_pick, /obj/item/lockpick_set/electronic_pick)
 
+	// Noise per failed event — masters are near-silent; bobby pins jangle
+	if(is_bobby_pin)
+		pick_noise_level = 3
+	else if(is_master_pick)
+		pick_noise_level = 0
+	else
+		pick_noise_level = 1
+
+	// Record initial uses for pick wear calculation
+	pick_initial_uses = pick.uses_left
+
+	// TRAIT_LOCKPICKING: professional muscle memory — wider feel, quieter work
+	if(isliving(the_user) && HAS_TRAIT(the_user, TRAIT_LOCKPICKING))
+		has_lockpick_trait = TRUE
+		luck       = min(10, luck + 2)
+		perception = min(10, perception + 2)
+
 	// Bobby pin cannot handle tier 3+ locks
 	if(is_bobby_pin && lock_tier > 2)
 		feedback = "Your bobby pin is too flimsy for this lock — it needs a proper pick."
@@ -171,6 +211,17 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		ui_interact(the_user)
 		addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
 		return
+
+	// Broken pick fragment check — a snapped tip jams the lock until fished out
+	var/turf/frag_turf = get_turf(the_target)
+	for(var/obj/item/pick_fragment/frag in frag_turf)
+		if(frag.stuck_in == the_target)
+			feedback = "A broken pick tip is jammed in the lock. Fish it out with a screwdriver first."
+			phase = "failed"
+			result = FALSE
+			ui_interact(the_user)
+			addtimer(CALLBACK(src, PROC_REF(close_ui)), 2.5 SECONDS)
+			return
 
 	generate_pins()
 
@@ -188,11 +239,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	// Electronic pick auto-sets pin 1
 	if(is_electronic_pick && pins.len >= 1)
 		pins[1]["set"] = TRUE
-		current_pin = 2
-		feedback = "The electronic pick buzzes — pin 1 located automatically! Handle the rest manually."
+		current_pin = get_binding_pin()
+		feedback = "The electronic pick buzzes — pin 1 set! Pin [current_pin] is now binding."
 		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
 	else
-		feedback = "Insert your pick and find the correct position for each pin. You can focus any pin freely."
+		current_pin = get_binding_pin()
+		feedback = "Pin [current_pin] is binding — the cylinder presses on it. Find the right height and set it."
 
 	// Load partial save state from a previous give_up (tension wrench only), if any
 	var/ref = "\ref[the_target]"
@@ -219,13 +271,25 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 						pins[idx2]["tried"] = tried_restore
 					if(mem["tried_hints"])
 						pins[idx2]["tried_hints"] = mem["tried_hints"]
-		// Advance current_pin to the first unset pin
-		current_pin = 1
-		while(current_pin <= pins.len && pins[current_pin]["set"])
-			current_pin++
+		// Advance current_pin to the binding pin (skips already-restored set pins)
+		var/restored_binding = get_binding_pin()
+		current_pin = restored_binding ? restored_binding : pins.len
 		var/loaded = set_indices.len
 		if(current_pin <= pins.len)
-			feedback = "Your tension wrench held — [loaded] [loaded == 1 ? "pin" : "pins"] already set. You remember your previous attempts."
+			feedback = "Tension held — [loaded] [loaded == 1 ? "pin" : "pins"] still set. Pin [current_pin] is now binding."
+
+	// Tension-fatigue timer: tier 3+ locks require sustained hand pressure.
+	// Your grip eventually cramps, dropping set pins.
+	timer_start = world.time
+	var/base_timer = 0
+	switch(lock_tier)
+		if(3) base_timer = 1800  // 180 s
+		if(4) base_timer = 1200  // 120 s
+		if(5) base_timer = 900   // 90 s
+	if(base_timer > 0)
+		if(has_lockpick_trait) base_timer += 600  // +60 s
+		if(is_master_pick)     base_timer += 300  // +30 s (ergonomic grip)
+		timer_duration = base_timer
 
 	// Anchor the user — prevents Move() from being called at all by the BYOND
 	// client, which stops bump sounds when pressing movement keys near the door.
@@ -240,11 +304,22 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	RegisterSignal(user, COMSIG_MOB_ATTACK_HAND, PROC_REF(on_user_hit))
 	RegisterSignal(user, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_user_hit))
 
+	// Overhead icon so bystanders can see the player is lockpicking
+	pick_overlay = mutable_appearance('icons/mob/actions/actions_flightsuit.dmi', "flightsuit_lock")
+	pick_overlay.pixel_y = 28
+	pick_overlay.alpha = 195
+	var/matrix/M = matrix()
+	M.Scale(0.55)
+	pick_overlay.transform = M
+	user.add_overlay(pick_overlay)
+
 	ui_interact(the_user)
 
 /datum/lockpicking_minigame/Destroy()
 	if(user && !QDELETED(user))
 		user.anchored = was_anchored
+		if(pick_overlay)
+			user.cut_overlay(pick_overlay)
 		UnregisterSignal(user, list(COMSIG_MOB_DEATH, COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_ITEM_ATTACK))
 	SStgui.close_uis(src)
 	return ..()
@@ -296,61 +371,170 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	attempts_left = max_attempts
 
 	pins = list()
+	// If the lock already has a stored solution (same pin count), reuse it so
+	// the combination stays consistent across attempts.  Per-picker stats still
+	// affect zone_size, attempts_left, and hint detail — only the raw
+	// positions/types are fixed to the physical lock.
+	var/use_stored = the_lock && the_lock.pin_solution \
+		&& (the_lock.pin_solution.len == num_pins)
 	for(var/i in 1 to num_pins)
-		var/max_start = max(10 - zone_size, 1)
-		var/min_pos   = rand(1, max_start)
-		var/max_pos   = min(min_pos + zone_size - 1, 10)
-		// False zone for tier 4+ — a single non-overlapping decoy position
+		var/min_pos
+		var/max_pos
 		var/false_min = 0
 		var/false_max = 0
-		if(lock_tier >= 4)
-			var/tries = 10
-			while(tries > 0)
-				var/candidate = rand(1, 10)
-				if(candidate < min_pos - 1 || candidate > max_pos + 1)
-					false_min = candidate
-					false_max = candidate
-					break
-				tries--
-		// Spool pins (tier 3+): must be approached from below (last move upward) to set.
 		var/is_spool = FALSE
-		if(lock_tier >= 3 && !is_bobby_pin)
-			var/spool_chance = (lock_tier - 2) * 20  // 20% / 40% / 60% for tiers 3/4/5
-			if(prob(spool_chance))
-				is_spool = TRUE
-				min_pos = max(min_pos, 3)  // ensure room to approach from below
-				max_pos = min(min_pos + zone_size - 1, 10)
-		// Security pins (tier 4+): a failed set attempt jars loose a neighboring set pin.
-		// A pin cannot be both spool and security.
 		var/is_security = FALSE
-		if(lock_tier >= 4 && !is_spool && !is_bobby_pin)
-			var/sec_chance = (lock_tier - 3) * 30  // 30% / 60% for tiers 4/5
-			is_security = prob(sec_chance)
+		var/stack_height
+		if(use_stored)
+			var/list/sp = the_lock.pin_solution[i]
+			stack_height = sp["stack_height"]
+			false_min    = sp["false_min"]
+			false_max    = sp["false_max"]
+			is_spool     = sp["spool"]
+			is_security  = sp["security"]
+			// Recompute zone around the stored center using THIS picker's zone_size.
+			// This keeps the combination fixed while still rewarding skilled pickers
+			// with a more forgiving window.
+			var/true_center = sp["true_center"]
+			var/max_start   = max(10 - zone_size, 1)
+			min_pos = clamp(true_center - round(zone_size / 2), 1, max_start)
+			max_pos = min(min_pos + zone_size - 1, 10)
+		else
+			// Stack height (1–5) biases where the pin's zone sits vertically.
+			// Short key pins (1–2) have zones near the bottom; tall (4–5) near the top.
+			stack_height  = rand(1, 5)
+			var/height_center = clamp(stack_height + 2, 1 + round(zone_size / 2), 10 - round(zone_size / 2) + 1)
+			var/max_start     = max(10 - zone_size, 1)
+			min_pos       = clamp(height_center - round(zone_size / 2) + rand(-1, 1), 1, max_start)
+			max_pos       = min(min_pos + zone_size - 1, 10)
+			// False zone for tier 4+ — a single non-overlapping decoy position
+			if(lock_tier >= 4)
+				var/tries = 10
+				while(tries > 0)
+					var/candidate = rand(1, 10)
+					if(candidate < min_pos - 1 || candidate > max_pos + 1)
+						false_min = candidate
+						false_max = candidate
+						break
+					tries--
+			// Spool pins (tier 3+): must be approached from below (last move upward) to set.
+			if(lock_tier >= 3 && !is_bobby_pin)
+				var/spool_chance = (lock_tier - 2) * 20  // 20% / 40% / 60% for tiers 3/4/5
+				if(prob(spool_chance))
+					is_spool = TRUE
+					min_pos = max(min_pos, 3)  // ensure room to approach from below
+					max_pos = min(min_pos + zone_size - 1, 10)
+			// Security pins (tier 4+): a failed set attempt jars loose a neighboring set pin.
+			// A pin cannot be both spool and security.
+			if(lock_tier >= 4 && !is_spool && !is_bobby_pin)
+				var/sec_chance = (lock_tier - 3) * 30  // 30% / 60% for tiers 4/5
+				is_security = prob(sec_chance)
 		pins += list(list(
-			"pos"         = 5,
-			"min"         = min_pos,
-			"max"         = max_pos,
-			"set"         = FALSE,
-			"hint"        = -1,         // distance from real zone on last attempt; -1 = no attempt
-			"last_dir"    = 0,          // 1 = go up, -1 = go down
-			"last_pos"    = 0,          // pin position at time of last failed set attempt
-			"last_move"   = 0,          // direction of last move on this pin (1 = up, -1 = down)
-			"moves"       = 0,          // move count for tension mechanic
-			"false_min"   = false_min,
-			"false_max"   = false_max,
-			"tried"       = list(),     // positions that produced a failed set_pin
-			"tried_hints" = list(),     // assoc: position string -> hint distance
-			"spool"       = is_spool,   // must approach from below to set correctly
-			"security"    = is_security,// failed set jars loose a neighboring set pin
-			"decayed"     = FALSE       // was previously set then vibrated loose
+			"pos"          = 5,
+			"min"          = min_pos,
+			"max"          = max_pos,
+			"set"          = FALSE,
+			"hint"         = -1,
+			"last_dir"     = 0,
+			"last_pos"     = 0,
+			"last_move"    = 0,
+			"moves"        = 0,
+			"false_min"    = false_min,
+			"false_max"    = false_max,
+			"tried"        = list(),
+			"tried_hints"  = list(),
+			"spool"        = is_spool,
+			"security"     = is_security,
+			"decayed"      = FALSE,
+			"overset"      = FALSE,
+			"stack_height" = stack_height
 		))
+
+	// Binding order
+	if(use_stored)
+		bind_order = the_lock.pin_bind_order.Copy()
+	else
+		bind_order = list()
+		for(var/j in 1 to pins.len)
+			bind_order += j
+		bind_order = shuffle(bind_order)
+		// Persist solution on the lock for all future attempts
+		if(the_lock)
+			var/list/solution = list()
+			for(var/k in 1 to pins.len)
+				solution += list(list(
+					"true_center"  = pins[k]["min"] + round((zone_size - 1) / 2),
+					"false_min"    = pins[k]["false_min"],
+					"false_max"    = pins[k]["false_max"],
+					"spool"        = pins[k]["spool"],
+					"security"     = pins[k]["security"],
+					"stack_height" = pins[k]["stack_height"]
+				))
+			the_lock.pin_solution   = solution
+			the_lock.pin_bind_order = bind_order.Copy()
+
+/**
+ * Returns the 1-indexed number of the currently binding pin.
+ * The binding pin is the first unset pin in bind_order — the one
+ * the cylinder's rotational force is pressing against under tension.
+ * Returns 0 when all pins are set.
+ */
+/datum/lockpicking_minigame/proc/get_binding_pin()
+	for(var/i in 1 to bind_order.len)
+		if(!pins[bind_order[i]]["set"])
+			return bind_order[i]
+	return 0
 
 /// Sleeps until the mini-game is fully resolved (closed = TRUE).
 /datum/lockpicking_minigame/proc/wait()
 	while(!closed && !QDELETED(src))
 		if(!QDELETED(user) && user.stat >= UNCONSCIOUS && phase == "picking")
 			on_user_incapacitated()
+		if(phase == "picking" && timer_duration > 0)
+			var/elapsed = world.time - timer_start
+			var/remaining = timer_duration - elapsed
+			if(remaining <= 300 && !timer_warning_sent)
+				timer_warning_sent = TRUE
+				feedback = "WARNING: Your hand is cramping — you have about 30 seconds before tension slips!"
+				SStgui.update_uis(src)
+			if(remaining <= 0)
+				on_tension_fatigue()
 		stoplag(1)
+
+/**
+ * Fires when the tension-fatigue timer expires.
+ * Realistically: your wrist cramps from holding the wrench — pins slip.
+ */
+/datum/lockpicking_minigame/proc/on_tension_fatigue()
+	if(phase != "picking")
+		return
+	// Reset the timer for the next round of fatigue
+	timer_start = world.time
+	timer_warning_sent = FALSE
+	attempts_left--
+	// Every set pin drops — the spring overcomes the tension wrench
+	var/lost = 0
+	for(var/list/pin in pins)
+		if(pin["set"])
+			pin["set"]   = FALSE
+			pin["pos"]   = 5
+			pin["moves"] = 0
+			pin["decayed"] = TRUE
+			lost++
+	playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 70, TRUE, -1)
+	if(lost > 0)
+		feedback = "Your hand cramps! The tension wrench slips — [lost] pin[lost != 1 ? "s" : ""] drop[lost == 1 ? "s" : ""]!"
+	else
+		feedback = "Your hand cramps but you barely hold tension — nothing drops."
+	if(attempts_left <= 0)
+		phase  = "failed"
+		result = FALSE
+		feedback = "Your grip gives out completely. The lock defeats you."
+		jam_target()
+		SStgui.update_uis(src)
+		addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+	else
+		SStgui.update_uis(src)
 
 /// Called when the user goes unconscious mid-pick (detected in wait loop).
 /datum/lockpicking_minigame/proc/on_user_incapacitated()
@@ -490,19 +674,22 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		var/tension = clamp(round(pin["moves"] / 2.0), 0, 5)
 		var/list/pin_tried_ui = pin["tried"]
 		pin_data += list(list(
-			"pos"        = pin["pos"],
-			"set"        = pin["set"],
-			"active"     = (i == current_pin && phase == "picking" && !pin["set"]),
-			"hint"       = pin["hint"],
-			"lastDir"    = pin["last_dir"],
-			"lastPos"    = pin["last_pos"],
-			"lastMove"   = pin["last_move"],
-			"tension"    = tension,
-			"tried"      = pin_tried_ui,
-			"triedHints" = pin["tried_hints"],
-			"spool"      = pin["spool"],
-			"security"   = pin["security"],
-			"decayed"    = pin["decayed"]
+			"pos"         = pin["pos"],
+			"set"         = pin["set"],
+			"active"      = (i == current_pin && phase == "picking" && !pin["set"]),
+			"hint"        = pin["hint"],
+			"lastDir"     = pin["last_dir"],
+			"lastPos"     = pin["last_pos"],
+			"lastMove"    = pin["last_move"],
+			"tension"     = tension,
+			"tried"       = pin_tried_ui,
+			"triedHints"  = pin["tried_hints"],
+			"spool"       = pin["spool"],
+			"security"    = pin["security"],
+			"decayed"     = pin["decayed"],
+			"overset"     = pin["overset"],
+			"spoolFeel"   = pin["spool"] && !pin["set"] && pin["pos"] >= pin["min"] && pin["pos"] <= pin["max"] && pin["last_move"] == -1,
+			"stackHeight" = pin["stack_height"]
 		))
 	data["pins"]         = pin_data
 	data["pinsSet"]      = pins_set
@@ -519,6 +706,16 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	data["isDark"]        = dark_penalty
 	data["isHurt"]        = pain_penalty
 	data["wearingGloves"] = glove_penalty
+	data["hasTrait"]      = has_lockpick_trait
+	data["noiseLevel"]    = accumulated_noise
+	data["timerDuration"] = timer_duration
+	data["timerElapsed"]  = (timer_duration > 0) ? min(timer_duration, world.time - timer_start) : 0
+	data["bindingPin"]    = get_binding_pin()
+	var/pick_wear = 0
+	if(!QDELETED(pick) && pick_initial_uses > 0)
+		var/wear_ratio = 1.0 - (pick.uses_left / pick_initial_uses)
+		pick_wear = clamp(round(wear_ratio * 4), 0, 3)
+	data["pickWear"]      = pick_wear
 	return data
 
 /datum/lockpicking_minigame/ui_close(mob/user)
@@ -539,57 +736,101 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 	switch(action)
 		if("move_up")
-			// Tension snap check before moving
-			if(cur_pin["moves"] >= 10)
-				snap_pick()
-				return TRUE
-			var/up_cost = agility_tension_cost()
-			// Electronic pick motor stall: pins 3+ have a 15% chance of extra tension per move
-			if(is_electronic_pick && current_pin >= 3 && prob(15))
+			var/binding_num = get_binding_pin()
+			var/is_binding  = (binding_num > 0 && current_pin == binding_num)
+			// Non-binding pins feel loose — no cylinder pressure, no pick stress
+			var/up_cost = is_binding ? agility_tension_cost() : 0
+			// Electronic pick stall only applies to the binding pin
+			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(15))
 				up_cost++
 				feedback = "The pick's motor stutters — extra tension!"
-			cur_pin["moves"] = min(cur_pin["moves"] + up_cost, 10)
+			// Snap only possible under cylinder pressure
+			if(is_binding && cur_pin["moves"] >= 10)
+				snap_pick()
+				return TRUE
+			if(up_cost > 0)
+				cur_pin["moves"] = min(cur_pin["moves"] + up_cost, 10)
 			if(cur_pin["pos"] < 10)
 				cur_pin["pos"]++
+			else if(is_binding && !cur_pin["overset"])
+				// Overset: driver pin slides below the shear line, jamming the pin
+				cur_pin["overset"] = TRUE
+				feedback = "Overdriven! The driver pin drops below the shear line — lower the pin all the way to free it."
 			cur_pin["last_move"] = 1
 			total_moves++
-			update_tension_feedback(cur_pin["moves"])
+			if(is_binding)
+				update_tension_feedback(cur_pin["moves"])
 			. = TRUE
 
 		if("move_down")
-			// Tension snap check before moving
-			if(cur_pin["moves"] >= 10)
-				snap_pick()
-				return TRUE
-			var/down_cost = agility_tension_cost()
-			// Electronic pick motor stall: pins 3+ have a 15% chance of extra tension per move
-			if(is_electronic_pick && current_pin >= 3 && prob(15))
+			var/binding_num = get_binding_pin()
+			var/is_binding  = (binding_num > 0 && current_pin == binding_num)
+			var/down_cost   = is_binding ? agility_tension_cost() : 0
+			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(15))
 				down_cost++
 				feedback = "The pick's motor stutters — extra tension!"
-			cur_pin["moves"] = min(cur_pin["moves"] + down_cost, 10)
+			if(is_binding && cur_pin["moves"] >= 10)
+				snap_pick()
+				return TRUE
+			if(down_cost > 0)
+				cur_pin["moves"] = min(cur_pin["moves"] + down_cost, 10)
 			if(cur_pin["pos"] > 1)
 				cur_pin["pos"]--
+				// Clear overset once fully lowered — driver pin is free again
+				if(cur_pin["overset"] && cur_pin["pos"] <= 1)
+					cur_pin["overset"] = FALSE
+					feedback = "The driver pin pops free — you can set this pin again."
+			// Spool false-set feel: entering the zone from above creates a subtle
+			// counter-rotation — the cylinder gives slightly, then the spool catches.
+			if(cur_pin["spool"] && !cur_pin["set"] && !cur_pin["overset"] \
+				&& cur_pin["pos"] >= cur_pin["min"] && cur_pin["pos"] <= cur_pin["max"] \
+				&& cur_pin["last_move"] != 1)
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 25, FALSE, -6)
+				if(is_binding)
+					feedback = "The cylinder gives slightly... then catches. Something's different about this pin."
 			cur_pin["last_move"] = -1
 			total_moves++
-			update_tension_feedback(cur_pin["moves"])
+			if(is_binding)
+				update_tension_feedback(cur_pin["moves"])
 			. = TRUE
 
 		if("select_pin")
-			// Non-linear pin focus: player can work on any unset pin freely
+			// Non-linear pin focus: player can scout any unset pin
 			var/pin_idx = text2num(params["pin"])
 			if(!pin_idx || pin_idx < 1 || pin_idx > pins.len)
 				return
 			if(pins[pin_idx]["set"])
 				return  // already set, nothing to do
 			current_pin = pin_idx
-			var/list/tpin = pins[pin_idx]
-			if(tpin["hint"] >= 0)
-				feedback = "Focusing pin [pin_idx]. You remember it last went [tpin["last_dir"] > 0 ? "too low" : "too high"]."
+			var/binding_sel = get_binding_pin()
+			var/list/tpin   = pins[pin_idx]
+			if(pin_idx == binding_sel)
+				if(tpin["hint"] >= 0)
+					feedback = "Pin [pin_idx] (BINDING). Last attempt: [tpin["last_dir"] > 0 ? "too low" : "too high"]."
+				else
+					feedback = "Pin [pin_idx] is binding — this is your target. Work it carefully."
 			else
-				feedback = "Focusing pin [pin_idx]."
+				if(tpin["hint"] >= 0)
+					feedback = "Pin [pin_idx] is loose. (Last: [tpin["last_dir"] > 0 ? "needed higher" : "needed lower"]) Binding pin is [binding_sel]."
+				else
+					feedback = "Pin [pin_idx] is loose — not binding right now. Binding pin is pin [binding_sel]."
 			. = TRUE
 
 		if("set_pin")
+			// Non-binding pin: springs back instantly, no attempt consumed.
+			// The cylinder isn't pressing on it — it has nothing to catch on.
+			var/binding_check = get_binding_pin()
+			if(binding_check > 0 && current_pin != binding_check)
+				cur_pin["pos"]       = 5
+				cur_pin["last_move"] = 0
+				feedback = "The pin springs free — it's loose under current tension. The binding pin is pin [binding_check]."
+				. = TRUE
+				return .
+			// Overset: driver pin is jammed below the shear line.
+			if(cur_pin["overset"])
+				feedback = "The pin is overdriven — lower it all the way to position 1 to free the driver pin."
+				. = TRUE
+				return .
 			var/pos = cur_pin["pos"]
 			attempt_made = TRUE
 
@@ -630,17 +871,10 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				cur_pin["set"]   = TRUE
 				cur_pin["moves"] = 0
 				playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
-				// Advance past already-set pins
 				var/just_set = current_pin
-				current_pin++
-				while(current_pin <= pins.len && pins[current_pin]["set"])
-					current_pin++
-				// If we overshot (non-linear play left earlier pins unset), wrap to first unset pin
-				if(current_pin > pins.len)
-					for(var/j in 1 to pins.len)
-						if(!pins[j]["set"])
-							current_pin = j
-							break
+				// Advance focus to the next binding pin in the shuffled bind_order
+				var/next_binding = get_binding_pin()
+				current_pin = (next_binding > 0) ? next_binding : 1
 				// Check for pin decay on tier 3+ locks
 				var/decayed = maybe_decay_pins(just_set)
 				if(all_pins_set())
@@ -681,6 +915,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', 45, TRUE, -4)
 				else
 					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -4)
+				// Noise alert: failed sets scrape and click. Loud picks alert bystanders.
+				check_noise(dist_to_zone <= 2 ? 1 : 2)
 
 				var/dir_text = direction == 1 ? "too low — try going higher" : "too high — try going lower"
 				switch(dist_to_zone)
@@ -738,6 +974,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			phase    = "failed"
 			feedback = "You carefully withdraw your lockpick."
 			result   = FALSE
+			gave_up  = TRUE
 			addtimer(CALLBACK(src, PROC_REF(close_ui)), 0.5 SECONDS)
 			. = TRUE
 
@@ -765,13 +1002,16 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	else if(moves >= 6)
 		feedback = "The tension is building... set the pin soon or risk snapping the pick!"
 
-/// Snaps the pick from excessive tension. Jams the lock and destroys the pick.
+/// Snaps the pick from excessive tension. Leaves a fragment in the lock.
 /datum/lockpicking_minigame/proc/snap_pick()
 	phase    = "failed"
 	result   = FALSE
-	feedback = "You overtorque the pick — SNAP! The mechanism jams. You'll need a crowbar."
+	feedback = "You overtorque the pick — SNAP! A fragment is stuck in the lock. Fish it out before trying again."
 	playsound(get_turf(target), 'sound/items/Wirecutter.ogg', 100, TRUE, -2)
-	jam_target()
+	// Spawn pick fragment — physically blocks the lock until removed
+	var/obj/item/pick_fragment/frag = new(get_turf(target))
+	frag.stuck_in = target
+	target.visible_message(span_warning("A piece of [user ? user.name + "'s" : "a"] pick snaps off inside [target]'s lock!"))
 	if(!QDELETED(pick))
 		qdel(pick)
 	addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
@@ -805,6 +1045,75 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			return i
 	return 0
 
+/**
+ * Accumulates noise from failed attempts and loud picks.
+ * When the tally passes the alert threshold, nearby bystanders hear the
+ * scraping and get a chat message — the volume and range scale with pick type.
+ */
+/datum/lockpicking_minigame/proc/check_noise(events)
+	var/effective = pick_noise_level * events
+	if(has_lockpick_trait)
+		effective = max(0, effective - 1)  // trained hands are quieter
+	accumulated_noise += effective
+	if(accumulated_noise < 5)
+		return
+	accumulated_noise = 0
+	// Range and message scale with how loud the pick type is
+	var/alert_range
+	var/sound_msg
+	switch(pick_noise_level)
+		if(3)  // bobby pin
+			alert_range = 8
+			sound_msg = "There's loud metallic scraping coming from [target]!"
+		if(2)
+			alert_range = 5
+			sound_msg = "You hear suspicious scraping near [target]."
+		if(1)
+			alert_range = 3
+			sound_msg = "There's a faint metallic click from [target]."
+		else  // master pick: silent, no alert
+			return
+	for(var/mob/M in view(alert_range, get_turf(target)))
+		if(M == user)
+			continue
+		to_chat(M, span_warning(sound_msg))
+
 /// Closes the TGUI after a short delay so the player can read the outcome.
 /datum/lockpicking_minigame/proc/close_ui()
 	SStgui.close_uis(src)
+
+// =====================================================
+// PICK FRAGMENT ITEM
+// =====================================================
+
+/**
+ * A broken pick tip wedged inside a lock cylinder.
+ * Blocks all further picking attempts until removed with a screwdriver
+ * or similar fine tool. Spawned when snap_pick() fires.
+ */
+/obj/item/pick_fragment
+	name = "pick fragment"
+	desc = "A jagged metal shard snapped from a lockpick inside the lock cylinder. \
+			You could fish it out with a screwdriver."
+	icon = 'icons/obj/fallout/lockbox.dmi'
+	icon_state = "basic_lockpick"
+	w_class = WEIGHT_CLASS_TINY
+	/// The lock object this fragment is stuck inside (null once removed).
+	var/atom/stuck_in = null
+
+/obj/item/pick_fragment/examine(mob/user)
+	. = ..()
+	if(stuck_in)
+		. += span_warning("It's lodged inside [stuck_in]'s lock mechanism. Use a screwdriver to extract it.")
+
+/// A screwdriver extracts the fragment from the lock.
+/obj/item/pick_fragment/attackby(obj/item/tool, mob/user, params)
+	if(istype(tool, /obj/item/screwdriver))
+		if(stuck_in)
+			to_chat(user, span_notice("You carefully work the pick fragment free from [stuck_in]."))
+			stuck_in = null
+		else
+			to_chat(user, span_notice("You pry the fragment loose."))
+		user.put_in_hands(src)
+		return
+	return ..()

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -149,6 +149,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/timer_duration = 0
 	/// TRUE once the 30-second cramp warning has been issued
 	var/timer_warning_sent = FALSE
+	/// Fractional tick accumulator for sneak-cramp drain (30% faster fatigue while sneaking)
+	var/sneak_drain_accum = 0
 	/// Whether the user has TRAIT_LOCKPICKING
 	var/has_lockpick_trait = FALSE
 	/// Shuffled list of pin indices determining binding order for this lock
@@ -310,9 +312,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 	// Overhead icon so bystanders can see the player is lockpicking.
 	// Alpha scales with picker skill: high perception+agility = subtler (lower alpha).
+	// mouse_opacity = 0 makes the overlay non-interactive — BYOND passes clicks
+	// through it to the tile below, so observers standing nearby aren't bumped north.
 	pick_overlay = mutable_appearance('icons/mob/actions/actions_flightsuit.dmi', "flightsuit_lock")
 	pick_overlay.pixel_y = 28
-	pick_overlay.alpha = clamp(240 - (perception + agility - 2) * 10, 80, 240)
+	pick_overlay.mouse_opacity = 0
+	pick_overlay.alpha = clamp(240 - (perception + agility - 2) * 15, 20, 240)
 	var/matrix/M = matrix()
 	M.Scale(0.55)
 	pick_overlay.transform = M
@@ -498,11 +503,22 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		if(!QDELETED(user) && user.stat >= UNCONSCIOUS && phase == "picking")
 			on_user_incapacitated()
 		if(phase == "picking" && timer_duration > 0)
+			// Sneaking posture (walk intent) tenses the shoulders and forearms —
+			// the timer burns 30% faster, draining in whole-tick increments.
+			if(isliving(user) && !QDELETED(user) && user:m_intent == MOVE_INTENT_WALK)
+				sneak_drain_accum += 0.3
+				if(sneak_drain_accum >= 1)
+					var/drain = round(sneak_drain_accum)
+					sneak_drain_accum -= drain
+					timer_start -= drain  // shift start backward = more elapsed time
 			var/elapsed = world.time - timer_start
 			var/remaining = timer_duration - elapsed
 			if(remaining <= 300 && !timer_warning_sent)
 				timer_warning_sent = TRUE
-				feedback = "WARNING: Your hand is cramping — you have about 30 seconds before tension slips!"
+				var/cramp_msg = "WARNING: Your hand is cramping — you have about 30 seconds before tension slips!"
+				if(isliving(user) && !QDELETED(user) && user:m_intent == MOVE_INTENT_WALK)
+					cramp_msg += " (Sneaking is tensing your whole arm — stand normally if you can.)"
+				feedback = cramp_msg
 				SStgui.update_uis(src)
 			if(remaining <= 0)
 				on_tension_fatigue()
@@ -725,6 +741,11 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		var/wear_ratio = 1.0 - (pick.uses_left / pick_initial_uses)
 		pick_wear = clamp(round(wear_ratio * 4), 0, 3)
 	data["pickWear"]      = pick_wear
+	var/is_sneaking = FALSE
+	if(isliving(user))
+		var/mob/living/L = user
+		is_sneaking = (L.m_intent == MOVE_INTENT_WALK)
+	data["isSneaking"] = is_sneaking
 	return data
 
 /datum/lockpicking_minigame/ui_close(mob/user)
@@ -745,6 +766,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 	// Guard: after non-linear play current_pin may sit past the end of the list.
 	var/list/cur_pin = (current_pin >= 1 && current_pin <= pins.len) ? pins[current_pin] : null
+	// Sneak (walk intent) muffles the picker's physical sounds — checked once per action.
+	var/sneaking = isliving(user) && (user:m_intent == MOVE_INTENT_WALK)
 
 	switch(action)
 		if("move_up")
@@ -904,12 +927,14 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					phase    = "success"
 					feedback = "The lock clicks open!"
 					result   = TRUE
-					playsound(get_turf(target), 'sound/machines/BoltsUp.ogg', 60, FALSE, -12)
+					// Final click: quiet enough that only nearby listeners catch it.
+					// Sneaking makes it even subtler — just a faint mechanical release.
+					playsound(get_turf(target), 'sound/machines/BoltsUp.ogg', sneaking ? 20 : 35, FALSE, -14)
 					addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
 				else if(decayed > 0)
 					current_pin = decayed
 					feedback = "Pin [just_set] set — but pin [decayed] vibrates loose and slips back! Refocus."
-					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 40, TRUE, -14)
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), sneaking ? 20 : 40, TRUE, -14)
 				else
 					feedback = "Pin [just_set] set. Moving to pin [current_pin]..."
 
@@ -935,9 +960,9 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 				// Warmer sound for close attempts, colder thud for far misses
 				if(dist_to_zone <= 2)
-					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', 45, TRUE, -14)
+					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', sneaking ? 22 : 45, TRUE, -14)
 				else
-					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -14)
+					playsound(get_turf(target), 'sound/items/screwdriver.ogg', sneaking ? 28 : 55, TRUE, -14)
 				// Noise alert: failed sets scrape and click. Loud picks alert bystanders.
 				check_noise(dist_to_zone <= 2 ? 1 : 2)
 				// Perception-gated detail for nearby observers
@@ -972,7 +997,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 						if(current_pin > pins.len || pins[current_pin]["set"])
 							current_pin = reset_idx
 						feedback += " The serrated pin catches — pin [reset_idx] jolts loose!"
-						playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 60, TRUE, -12)
+						playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), sneaking ? 30 : 60, TRUE, -12)
 
 				// Bobby pin breakage: 25% chance to snap on each failed attempt
 				if(is_bobby_pin && prob(25))
@@ -996,7 +1021,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 						pins[j]["last_move"]    = 0
 						pins[j]["pin_attempts"] = 2
 					current_pin = get_binding_pin()
-					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 65, TRUE, -12)
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), sneaking ? 32 : 65, TRUE, -12)
 					if(attempts_left <= 0)
 						feedback = "The cylinder slams shut — you're out of attempts."
 						phase    = "failed"
@@ -1096,7 +1121,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	if(isliving(user))
 		var/mob/living/L = user
 		if(L.m_intent == MOVE_INTENT_WALK)
-			effective = round(effective * 0.5)
+			effective = round(effective * 0.25)  // sneaking cuts noise to 25% — very hard to hear
 	if(has_lockpick_trait)
 		effective = max(0, effective - 1)  // trained hands are quieter
 	accumulated_noise += effective
@@ -1166,7 +1191,14 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	// Categorise the pin's position in the cylinder as "front" or "back"
 	// so mid-perception observers get useful directional context.
 	var/half = (pin_num <= round(total_pins / 2)) ? "front" : "back"
-	for(var/mob/M in view(4, T))
+	// Sneaking (walk intent) makes the picker's movements quieter — the sounds are
+	// physically softer, so the effective range AND detail level drop for observers.
+	var/sneak_penalty = (isliving(user) && user:m_intent == MOVE_INTENT_WALK) ? 3 : 0
+	// Extended range: high-perception observers (7+) can pick out subtle sounds from
+	// further away. Past 4 tiles requires at least perception 7 just to catch anything.
+	// Sneaking shrinks the broadcast radius to 5 tiles.
+	var/broadcast_range = sneak_penalty ? 5 : 8
+	for(var/mob/M in view(broadcast_range, T))
 		if(M == user)
 			continue
 		if(!isliving(M))
@@ -1174,13 +1206,17 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		var/obs_perc = M.special_p
 		if(obs_perc <= 0)
 			continue
-		// Distance penalty: each tile beyond 2 costs 2 effective perception.
-		// Being right next to the lock (1-2 tiles) costs nothing — you can press
-		// your ear to the door. At 3-4 tiles the sound is muffled by air and
-		// ambient noise; you need sharper senses to pull the same detail.
 		var/obs_dist = get_dist(M, T)
+		// Past 4 tiles only perception 7+ can catch anything — the sound is too faint.
+		// When the picker is sneaking, that threshold tightens to 2 tiles.
+		var/far_threshold = sneak_penalty ? 2 : 4
+		if(obs_dist > far_threshold && obs_perc < 7)
+			continue
+		// Distance penalty: each tile beyond 2 costs 2 effective perception.
 		if(obs_dist > 2)
 			obs_perc -= (obs_dist - 2) * 2
+		// Sneak penalty: quieter sounds = harder to extract detail from them.
+		obs_perc -= sneak_penalty
 		if(obs_perc <= 0)
 			continue
 		// Identifying the picker by name requires line of sight — you need to see

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -89,6 +89,14 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/luck = 5
 	/// User's Agility SPECIAL stat (1–10)
 	var/agility = 5
+	/// User's Perception SPECIAL stat (1–10) — controls hint detail level
+	var/perception = 5
+	/// TRUE if the target turf is unlit (reduces effective zone size by 1)
+	var/dark_penalty = FALSE
+	/// TRUE if user has heavy injuries (adds extra tension chance per move)
+	var/pain_penalty = FALSE
+	/// TRUE if user is wearing gloves (treats Agility as 1 lower for tension)
+	var/glove_penalty = FALSE
 	/// Whether a master lockpick is being used
 	var/is_master_pick = FALSE
 	/// Whether a tension wrench is being used (halves pin decay chance)
@@ -99,8 +107,10 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/is_electronic_pick = FALSE
 
 	/// List of assoc lists per pin:
-	///   "pos", "min", "max", "set", "hint", "last_dir",
-	///   "moves" (tension counter), "false_min", "false_max"
+	///   "pos", "min", "max", "set", "hint", "last_dir", "last_move",
+	///   "moves" (tension counter), "false_min", "false_max",
+	///   "tried" (list of positions attempted), "tried_hints" (pos->hint map),
+	///   "last_pos" (pos at last failed set_pin), "spool", "security", "decayed"
 	var/list/pins = null
 	/// Index of the currently active pin (1-indexed)
 	var/current_pin = 1
@@ -115,14 +125,16 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	/// Ref string of target, stored for partial-state timer cleanup
 	var/partial_state_ref = ""
 
+	/// Set TRUE when the UI window closes, ending wait()
+	var/closed = FALSE
 	/// Game phase: "picking", "success", "failed"
 	var/phase = "picking"
 	/// Last feedback message shown in the UI
 	var/feedback = ""
 	/// null = in progress, TRUE = success, FALSE = fail/cancel
 	var/result = null
-	/// Set TRUE when the UI window closes, ending wait()
-	var/closed = FALSE
+	/// Whether the user was anchored before lockpicking began (restored on Destroy)
+	var/was_anchored = FALSE
 
 /datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier)
 	target    = the_target
@@ -131,7 +143,21 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	lock_tier = clamp(tier, 1, 5)
 	luck      = the_user.special_l
 	if(isliving(the_user))
-		agility = the_user.special_a
+		agility    = the_user.special_a
+		perception = the_user.special_p
+		// Injury penalty: shaking hands if badly hurt
+		var/mob/living/L = the_user
+		var/total_dmg = L.getBruteLoss() + L.getFireLoss()
+		if(total_dmg > 60)
+			pain_penalty = TRUE
+	// Environmental penalties — computed once at game start
+	var/turf/target_turf = get_turf(the_target)
+	if(target_turf && target_turf.is_softly_lit())
+		dark_penalty = TRUE
+	if(iscarbon(the_user))
+		var/mob/living/carbon/C = the_user
+		if(C.gloves)
+			glove_penalty = TRUE
 	is_master_pick     = istype(the_pick, /obj/item/lockpick_set/master)
 	is_tension_wrench  = istype(the_pick, /obj/item/lockpick_set/tension_wrench)
 	is_bobby_pin       = istype(the_pick, /obj/item/lockpick_set/bobby_pin)
@@ -148,6 +174,17 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 	generate_pins()
 
+	// Warn about active penalties
+	var/list/penalty_warnings = list()
+	if(dark_penalty)
+		penalty_warnings += "darkness"
+	if(pain_penalty)
+		penalty_warnings += "your injuries"
+	if(glove_penalty)
+		penalty_warnings += "your gloves"
+	if(penalty_warnings.len)
+		to_chat(the_user, span_warning("WARNING: [english_list(penalty_warnings)] will make this harder."))
+
 	// Electronic pick auto-sets pin 1
 	if(is_electronic_pick && pins.len >= 1)
 		pins[1]["set"] = TRUE
@@ -155,34 +192,70 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		feedback = "The electronic pick buzzes — pin 1 located automatically! Handle the rest manually."
 		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
 	else
-		feedback = "Insert your pick and find the correct position for each pin."
+		feedback = "Insert your pick and find the correct position for each pin. You can focus any pin freely."
 
-	// Load partial save state from a previous give_up, if any
+	// Load partial save state from a previous give_up (tension wrench only), if any
 	var/ref = "\ref[the_target]"
 	if(GLOB.lockpick_partial_states[ref])
 		var/list/saved = GLOB.lockpick_partial_states[ref]
 		GLOB.lockpick_partial_states -= ref
-		for(var/idx in saved)
+		// Restore set-pin indices
+		var/list/set_indices = saved["set"]
+		for(var/idx in set_indices)
 			if(idx <= pins.len && !pins[idx]["set"])
 				pins[idx]["set"] = TRUE
-		// Advance current_pin past already-set pins
+		// Restore per-pin memory (tried positions, hints)
+		var/list/pin_memory = saved["memory"]
+		if(pin_memory)
+			for(var/key in pin_memory)
+				var/idx2 = text2num(key)
+				if(idx2 >= 1 && idx2 <= pins.len)
+					var/list/mem = pin_memory[key]
+					var/list/tried_restore = mem["tried"]
+					pins[idx2]["hint"]     = mem["hint"]
+					pins[idx2]["last_dir"] = mem["last_dir"]
+					pins[idx2]["last_pos"] = mem["last_pos"]
+					if(tried_restore)
+						pins[idx2]["tried"] = tried_restore
+					if(mem["tried_hints"])
+						pins[idx2]["tried_hints"] = mem["tried_hints"]
+		// Advance current_pin to the first unset pin
 		current_pin = 1
 		while(current_pin <= pins.len && pins[current_pin]["set"])
 			current_pin++
-		var/loaded = saved.len
+		var/loaded = set_indices.len
 		if(current_pin <= pins.len)
-			feedback = "Your tension wrench held — [loaded] [loaded == 1 ? "pin" : "pins"] already set. Continue!"
+			feedback = "Your tension wrench held — [loaded] [loaded == 1 ? "pin" : "pins"] already set. You remember your previous attempts."
+
+	// Anchor the user — prevents Move() from being called at all by the BYOND
+	// client, which stops bump sounds when pressing movement keys near the door.
+	was_anchored = user.anchored
+	user.anchored = TRUE
 
 	// Register death signal for interruption handling
 	RegisterSignal(user, COMSIG_MOB_DEATH, PROC_REF(on_user_death))
+	// Block movement while picking — prevents WASD from walking away
+	RegisterSignal(user, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(block_user_move))
+	// Interrupt picking when struck — getting hit breaks concentration
+	RegisterSignal(user, COMSIG_MOB_ATTACK_HAND, PROC_REF(on_user_hit))
+	RegisterSignal(user, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_user_hit))
 
 	ui_interact(the_user)
 
 /datum/lockpicking_minigame/Destroy()
 	if(user && !QDELETED(user))
-		UnregisterSignal(user, COMSIG_MOB_DEATH)
+		user.anchored = was_anchored
+		UnregisterSignal(user, list(COMSIG_MOB_DEATH, COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_ITEM_ATTACK))
 	SStgui.close_uis(src)
 	return ..()
+
+/// Blocks player movement and restores facing toward the target while picking.
+/datum/lockpicking_minigame/proc/block_user_move(datum/source)
+	SIGNAL_HANDLER
+	var/face_dir = get_dir(user, target)
+	if(face_dir)
+		user.setDir(face_dir)
+	return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
 
 /**
  * Generates the pin array based on lock tier, Luck, Agility, and pick type.
@@ -200,13 +273,13 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			base_zone_size = 3
 		if(3)
 			num_pins = 3
-			base_zone_size = 2
+			base_zone_size = 3  // was 2 — spool pins add difficulty on tier 3+
 		if(4)
 			num_pins = 4
 			base_zone_size = 2
 		if(5)
 			num_pins = 5
-			base_zone_size = 1
+			base_zone_size = 2  // was 1 — spool/security/false zones add enough difficulty
 
 	// Luck bonus: (1–3) = -1, (4–6) = 0, (7–8) = +1, (9–10) = +2
 	var/luck_bonus      = clamp(round((luck - 4.5) / 2), -1, 2)
@@ -214,10 +287,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/locksmith_bonus = (agility >= 8) ? 1 : 0
 	// Pick bonus: master or electronic pick widens zones by 1
 	var/pick_bonus      = (is_master_pick || is_electronic_pick) ? 1 : 0
-	var/zone_size = clamp(base_zone_size + luck_bonus + locksmith_bonus + pick_bonus, 1, 7)
+	// Darkness penalty: can't see the lock well
+	var/dark_mod        = dark_penalty ? -1 : 0
+	var/zone_size = clamp(base_zone_size + luck_bonus + locksmith_bonus + pick_bonus + dark_mod, 1, 7)
 
-	// Attempts: base 6, minus tier, plus luck/pick bonuses; minimum 2
-	max_attempts  = max(6 - lock_tier + luck_bonus + (pick_bonus * 2), 2)
+	// Attempts: base 7, minus tier, plus luck/pick bonuses; minimum 2
+	max_attempts  = max(7 - lock_tier + luck_bonus + (pick_bonus * 2), 2)
 	attempts_left = max_attempts
 
 	pins = list()
@@ -237,16 +312,37 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					false_max = candidate
 					break
 				tries--
+		// Spool pins (tier 3+): must be approached from below (last move upward) to set.
+		var/is_spool = FALSE
+		if(lock_tier >= 3 && !is_bobby_pin)
+			var/spool_chance = (lock_tier - 2) * 20  // 20% / 40% / 60% for tiers 3/4/5
+			if(prob(spool_chance))
+				is_spool = TRUE
+				min_pos = max(min_pos, 3)  // ensure room to approach from below
+				max_pos = min(min_pos + zone_size - 1, 10)
+		// Security pins (tier 4+): a failed set attempt jars loose a neighboring set pin.
+		// A pin cannot be both spool and security.
+		var/is_security = FALSE
+		if(lock_tier >= 4 && !is_spool && !is_bobby_pin)
+			var/sec_chance = (lock_tier - 3) * 30  // 30% / 60% for tiers 4/5
+			is_security = prob(sec_chance)
 		pins += list(list(
-			"pos"       = 5,
-			"min"       = min_pos,
-			"max"       = max_pos,
-			"set"       = FALSE,
-			"hint"      = -1,       // distance from real zone on last attempt; -1 = no attempt
-			"last_dir"  = 0,        // 1 = go up, -1 = go down
-			"moves"     = 0,        // move count for tension mechanic
-			"false_min" = false_min,
-			"false_max" = false_max
+			"pos"         = 5,
+			"min"         = min_pos,
+			"max"         = max_pos,
+			"set"         = FALSE,
+			"hint"        = -1,         // distance from real zone on last attempt; -1 = no attempt
+			"last_dir"    = 0,          // 1 = go up, -1 = go down
+			"last_pos"    = 0,          // pin position at time of last failed set attempt
+			"last_move"   = 0,          // direction of last move on this pin (1 = up, -1 = down)
+			"moves"       = 0,          // move count for tension mechanic
+			"false_min"   = false_min,
+			"false_max"   = false_max,
+			"tried"       = list(),     // positions that produced a failed set_pin
+			"tried_hints" = list(),     // assoc: position string -> hint distance
+			"spool"       = is_spool,   // must approach from below to set correctly
+			"security"    = is_security,// failed set jars loose a neighboring set pin
+			"decayed"     = FALSE       // was previously set then vibrated loose
 		))
 
 /// Sleeps until the mini-game is fully resolved (closed = TRUE).
@@ -267,6 +363,21 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		jam_target()
 	else
 		feedback = "You fall unconscious! Your pick slips free of the lock."
+	SStgui.update_uis(src)
+	addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
+
+/// Signal handler — fires when the user is struck while picking.
+/datum/lockpicking_minigame/proc/on_user_hit(datum/source)
+	SIGNAL_HANDLER
+	if(phase != "picking")
+		return
+	phase  = "failed"
+	result = FALSE
+	save_partial_state()  // saves pins only if using tension_wrench or master pick
+	if(is_tension_wrench || is_master_pick)
+		feedback = "You're struck! The shock breaks your focus, but your tension wrench holds the pins."
+	else
+		feedback = "You're struck! The blow jolts your hand and the pick slips free."
 	SStgui.update_uis(src)
 	addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
 
@@ -307,17 +418,34 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
  * The state expires after 60 seconds.
  */
 /datum/lockpicking_minigame/proc/save_partial_state()
+	// Only tension wrenches (and master sets) can hold pins after give_up
+	if(!is_tension_wrench && !is_master_pick)
+		return
 	var/list/set_indices = list()
-	for(var/i in 1 to pins.len)
+	for(var/i in 1 to length(pins))
 		if(pins[i]["set"])
 			set_indices += i
-	if(set_indices.len)
-		partial_state_ref = "\ref[target]"
-		GLOB.lockpick_partial_states[partial_state_ref] = set_indices
-		addtimer(CALLBACK(src, PROC_REF(expire_partial_state)), 60 SECONDS)
-		var/n = set_indices.len
-		if(!QDELETED(user))
-			to_chat(user, span_notice("You leave your tension wrench in the lock — [n] [n == 1 ? "pin stays" : "pins stay"] set. Continue within 60 seconds to keep your progress."))
+	if(!set_indices.len)
+		return
+	// Collect per-pin memory (tried positions and last hint) for lock memory
+	var/list/pin_memory = list()
+	for(var/i in 1 to length(pins))
+		var/list/pin = pins[i]
+		var/list/pin_tried = pin["tried"]
+		if(pin_tried && length(pin_tried) > 0 || pin["hint"] >= 0)
+			pin_memory[num2text(i)] = list(
+				"hint"        = pin["hint"],
+				"last_dir"    = pin["last_dir"],
+				"last_pos"    = pin["last_pos"],
+				"tried"       = pin_tried,
+				"tried_hints" = pin["tried_hints"]
+			)
+	partial_state_ref = "\ref[target]"
+	GLOB.lockpick_partial_states[partial_state_ref] = list("set" = set_indices, "memory" = pin_memory)
+	addtimer(CALLBACK(src, PROC_REF(expire_partial_state)), 60 SECONDS)
+	var/n = set_indices.len
+	if(!QDELETED(user))
+		to_chat(user, span_notice("You ease your [is_master_pick ? "tension wrench" : "pick"] to hold the pins — [n] [n == 1 ? "pin stays" : "pins stay"] set. Continue within 60 seconds."))
 
 /datum/lockpicking_minigame/proc/expire_partial_state()
 	if(partial_state_ref)
@@ -360,13 +488,21 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			pins_set++
 		// Tension: 0–5 scale (moves / 2, clamped)
 		var/tension = clamp(round(pin["moves"] / 2.0), 0, 5)
+		var/list/pin_tried_ui = pin["tried"]
 		pin_data += list(list(
-			"pos"     = pin["pos"],
-			"set"     = pin["set"],
-			"active"  = (i == current_pin && phase == "picking" && !pin["set"]),
-			"hint"    = pin["hint"],
-			"lastDir" = pin["last_dir"],
-			"tension" = tension
+			"pos"        = pin["pos"],
+			"set"        = pin["set"],
+			"active"     = (i == current_pin && phase == "picking" && !pin["set"]),
+			"hint"       = pin["hint"],
+			"lastDir"    = pin["last_dir"],
+			"lastPos"    = pin["last_pos"],
+			"lastMove"   = pin["last_move"],
+			"tension"    = tension,
+			"tried"      = pin_tried_ui,
+			"triedHints" = pin["tried_hints"],
+			"spool"      = pin["spool"],
+			"security"   = pin["security"],
+			"decayed"    = pin["decayed"]
 		))
 	data["pins"]         = pin_data
 	data["pinsSet"]      = pins_set
@@ -377,8 +513,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	data["feedback"]     = feedback
 	data["lockTier"]     = lock_tier
 	data["luck"]         = luck
-	data["isMasterPick"] = is_master_pick
-	data["totalPins"]    = pins.len
+	data["perception"]    = perception
+	data["isMasterPick"]  = is_master_pick
+	data["totalPins"]     = pins.len
+	data["isDark"]        = dark_penalty
+	data["isHurt"]        = pain_penalty
+	data["wearingGloves"] = glove_penalty
 	return data
 
 /datum/lockpicking_minigame/ui_close(mob/user)
@@ -394,7 +534,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	if(phase != "picking")
 		return
 
-	var/list/cur_pin = pins[current_pin]
+	// Guard: after non-linear play current_pin may sit past the end of the list.
+	var/list/cur_pin = (current_pin >= 1 && current_pin <= pins.len) ? pins[current_pin] : null
 
 	switch(action)
 		if("move_up")
@@ -402,9 +543,15 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			if(cur_pin["moves"] >= 10)
 				snap_pick()
 				return TRUE
-			cur_pin["moves"] = min(cur_pin["moves"] + agility_tension_cost(), 10)
+			var/up_cost = agility_tension_cost()
+			// Electronic pick motor stall: pins 3+ have a 15% chance of extra tension per move
+			if(is_electronic_pick && current_pin >= 3 && prob(15))
+				up_cost++
+				feedback = "The pick's motor stutters — extra tension!"
+			cur_pin["moves"] = min(cur_pin["moves"] + up_cost, 10)
 			if(cur_pin["pos"] < 10)
 				cur_pin["pos"]++
+			cur_pin["last_move"] = 1
 			total_moves++
 			update_tension_feedback(cur_pin["moves"])
 			. = TRUE
@@ -414,11 +561,32 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			if(cur_pin["moves"] >= 10)
 				snap_pick()
 				return TRUE
-			cur_pin["moves"] = min(cur_pin["moves"] + agility_tension_cost(), 10)
+			var/down_cost = agility_tension_cost()
+			// Electronic pick motor stall: pins 3+ have a 15% chance of extra tension per move
+			if(is_electronic_pick && current_pin >= 3 && prob(15))
+				down_cost++
+				feedback = "The pick's motor stutters — extra tension!"
+			cur_pin["moves"] = min(cur_pin["moves"] + down_cost, 10)
 			if(cur_pin["pos"] > 1)
 				cur_pin["pos"]--
+			cur_pin["last_move"] = -1
 			total_moves++
 			update_tension_feedback(cur_pin["moves"])
+			. = TRUE
+
+		if("select_pin")
+			// Non-linear pin focus: player can work on any unset pin freely
+			var/pin_idx = text2num(params["pin"])
+			if(!pin_idx || pin_idx < 1 || pin_idx > pins.len)
+				return
+			if(pins[pin_idx]["set"])
+				return  // already set, nothing to do
+			current_pin = pin_idx
+			var/list/tpin = pins[pin_idx]
+			if(tpin["hint"] >= 0)
+				feedback = "Focusing pin [pin_idx]. You remember it last went [tpin["last_dir"] > 0 ? "too low" : "too high"]."
+			else
+				feedback = "Focusing pin [pin_idx]."
 			. = TRUE
 
 		if("set_pin")
@@ -448,6 +616,17 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 			// --- Real zone check ---
 			if(pos >= cur_pin["min"] && pos <= cur_pin["max"])
+				// Spool pin: must be approached from below (last_move upward).
+				// Descending into the zone creates a false click that springs back out.
+				if(cur_pin["spool"] && cur_pin["last_move"] == -1)
+					cur_pin["pos"]   = max(cur_pin["min"] - 2, 1)
+					cur_pin["moves"] = 0
+					cur_pin["last_move"] = 0
+					playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -3)
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 45, TRUE, -4)
+					feedback = "The pin clicks... then springs back! It's a spool pin — approach from lower positions (move up into the zone)."
+					. = TRUE
+					return .
 				cur_pin["set"]   = TRUE
 				cur_pin["moves"] = 0
 				playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
@@ -456,6 +635,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				current_pin++
 				while(current_pin <= pins.len && pins[current_pin]["set"])
 					current_pin++
+				// If we overshot (non-linear play left earlier pins unset), wrap to first unset pin
+				if(current_pin > pins.len)
+					for(var/j in 1 to pins.len)
+						if(!pins[j]["set"])
+							current_pin = j
+							break
 				// Check for pin decay on tier 3+ locks
 				var/decayed = maybe_decay_pins(just_set)
 				if(all_pins_set())
@@ -484,6 +669,10 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					direction    = -1
 				cur_pin["hint"]     = dist_to_zone
 				cur_pin["last_dir"] = direction
+				cur_pin["last_pos"] = pos
+				if(!(cur_pin["tried"] ~! pos))  // only add to tried if not already there
+					cur_pin["tried"] += pos
+					cur_pin["tried_hints"]["[pos]"] = dist_to_zone
 				cur_pin["pos"]      = 5
 				cur_pin["moves"]    = 0  // reset tension after a set attempt
 
@@ -504,6 +693,36 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					else
 						feedback = "The pin springs back hard — [dir_text]. Way off the mark."
 
+				// Security pin: a failed set attempt jars loose the nearest set pin
+				if(cur_pin["security"])
+					var/nearest_dist = 999
+					var/reset_idx = 0
+					for(var/j in 1 to pins.len)
+						if(j != current_pin && pins[j]["set"])
+							var/d = abs(j - current_pin)
+							if(d < nearest_dist)
+								nearest_dist = d
+								reset_idx = j
+					if(reset_idx > 0)
+						pins[reset_idx]["set"]     = FALSE
+						pins[reset_idx]["pos"]     = 5
+						pins[reset_idx]["moves"]   = 0
+						pins[reset_idx]["decayed"] = TRUE
+						if(current_pin > pins.len || pins[current_pin]["set"])
+							current_pin = reset_idx
+						feedback += " The serrated pin catches — pin [reset_idx] jolts loose!"
+						playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 60, TRUE, -3)
+
+				// Bobby pin breakage: 25% chance to snap on each failed attempt
+				if(is_bobby_pin && attempts_left > 0 && prob(25))
+					feedback += " The bobby pin snaps!"
+					phase  = "failed"
+					result = FALSE
+					if(!QDELETED(pick))
+						qdel(pick)
+					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+					. = TRUE
+					return .
 				if(attempts_left <= 0)
 					phase    = "failed"
 					result   = FALSE
@@ -527,11 +746,17 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
  * Low Agility has a chance to add extra tension (clumsy handling).
  */
 /datum/lockpicking_minigame/proc/agility_tension_cost()
-	if(agility <= 3)
-		return prob(30) ? 2 : 1  // Very clumsy: 30% chance of double tension
-	if(agility < 6)
-		return prob(15) ? 2 : 1  // Somewhat clumsy: 15% chance
-	return 1                     // Agility 6+ is always clean
+	// Glove penalty: treat agility as 1 lower (less fine motor control)
+	var/eff_agility = glove_penalty ? max(1, agility - 1) : agility
+	// Pain penalty: extra 15% chance of double tension (shaking hands)
+	var/pain_mod = pain_penalty ? 15 : 0
+	if(eff_agility <= 3)
+		return prob(30 + pain_mod) ? 2 : 1
+	if(eff_agility < 6)
+		return prob(15 + pain_mod) ? 2 : 1
+	if(pain_mod && prob(pain_mod))
+		return 2  // Even skilled hands tremble when badly hurt
+	return 1
 
 /// Updates feedback with tension warnings when pins are near snapping.
 /datum/lockpicking_minigame/proc/update_tension_feedback(moves)
@@ -572,10 +797,11 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	decay_chance = max(0, decay_chance - luck * 2)  // Luck reduces decay
 	for(var/i in 1 to just_set_pin - 1)
 		if(pins[i]["set"] && prob(decay_chance))
-			pins[i]["set"]   = FALSE
-			pins[i]["pos"]   = 5
-			pins[i]["hint"]  = -1
-			pins[i]["moves"] = 0
+			pins[i]["set"]     = FALSE
+			pins[i]["pos"]     = 5
+			pins[i]["moves"]   = 0
+			pins[i]["decayed"] = TRUE
+			// Keep hint/last_dir so the player retains positional memory
 			return i
 	return 0
 

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -980,13 +980,28 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					. = TRUE
 					return .
 				if(cur_pin["pin_attempts"] <= 0)
-					phase    = "failed"
-					result   = FALSE
-					feedback = "You've botched pin [current_pin] twice — the cylinder slams shut."
-					jam_target()
-					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+					// All pins spring back — cylinder drops. Lose one global attempt.
+					attempts_left--
+					for(var/j in 1 to pins.len)
+						pins[j]["set"]          = FALSE
+						pins[j]["pos"]          = 1
+						pins[j]["moves"]        = 0
+						pins[j]["decayed"]      = FALSE
+						pins[j]["overset"]      = FALSE
+						pins[j]["last_move"]    = 0
+						pins[j]["pin_attempts"] = 2
+					current_pin = get_binding_pin()
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 65, TRUE, -12)
+					if(attempts_left <= 0)
+						feedback = "The cylinder slams shut — you're out of attempts."
+						phase    = "failed"
+						result   = FALSE
+						jam_target()
+						addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+					else
+						feedback = "You botch pin [current_pin] badly — the cylinder drops and all pins spring back! ([attempts_left] attempt[attempts_left == 1 ? "" : "s"] left.)"
 				else if(cur_pin["pin_attempts"] == 1)
-					feedback += " (WARNING: Last chance on this pin!)"
+					feedback += " (WARNING: Last chance on this pin before the cylinder drops!)"
 			. = TRUE
 
 		if("give_up")

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -153,12 +153,13 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/list/bind_order = null
 	/// uses_left when the pick was first inserted (baseline for wear calculation)
 	var/pick_initial_uses = 0
-	/// Reference to the physical lock object — used to persist pin solution
-	var/obj/item/lock_construct/the_lock = null
+	/// Reference to the lockable object — used to persist pin solution.
+	/// May be a /obj/item/lock_construct (padlock) or /obj/machinery/door (faction door).
+	var/atom/the_lock = null
 	/// Overhead icon overlay displayed above the user's mob while picking
 	var/mutable_appearance/pick_overlay = null
 
-/datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier, obj/item/lock_construct/lock_ref = null)
+/datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier, atom/lock_ref = null)
 	target    = the_target
 	user      = the_user
 	pick      = the_pick
@@ -375,8 +376,9 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	// the combination stays consistent across attempts.  Per-picker stats still
 	// affect zone_size, attempts_left, and hint detail — only the raw
 	// positions/types are fixed to the physical lock.
-	var/use_stored = the_lock && the_lock.pin_solution \
-		&& (the_lock.pin_solution.len == num_pins)
+	var/list/stored_sol  = the_lock ? the_lock.vars["pin_solution"]  : null
+	var/list/stored_bind = the_lock ? the_lock.vars["pin_bind_order"] : null
+	var/use_stored = islist(stored_sol) && (stored_sol.len == num_pins)
 	for(var/i in 1 to num_pins)
 		var/min_pos
 		var/max_pos
@@ -386,7 +388,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		var/is_security = FALSE
 		var/stack_height
 		if(use_stored)
-			var/list/sp = the_lock.pin_solution[i]
+			var/list/sp = stored_sol[i]
 			stack_height = sp["stack_height"]
 			false_min    = sp["false_min"]
 			false_max    = sp["false_max"]
@@ -396,17 +398,15 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			// This keeps the combination fixed while still rewarding skilled pickers
 			// with a more forgiving window.
 			var/true_center = sp["true_center"]
-			var/max_start   = max(10 - zone_size, 1)
-			min_pos = clamp(true_center - round(zone_size / 2), 1, max_start)
+			var/max_start   = max(10 - zone_size + 1, 1)
+			min_pos = clamp(true_center - zone_size / 2, 1, max_start)
 			max_pos = min(min_pos + zone_size - 1, 10)
 		else
-			// Stack height (1–5) biases where the pin's zone sits vertically.
-			// Short key pins (1–2) have zones near the bottom; tall (4–5) near the top.
-			stack_height  = rand(1, 5)
-			var/height_center = clamp(stack_height + 2, 1 + round(zone_size / 2), 10 - round(zone_size / 2) + 1)
-			var/max_start     = max(10 - zone_size, 1)
-			min_pos       = clamp(height_center - round(zone_size / 2) + rand(-1, 1), 1, max_start)
-			max_pos       = min(min_pos + zone_size - 1, 10)
+			// Zone placed uniformly across the full 1–10 range — no center bias.
+			stack_height = rand(1, 5)  // cosmetic: kept for TGUI stack-height display
+			var/max_start = max(10 - zone_size + 1, 1)
+			min_pos = rand(1, max_start)
+			max_pos = min(min_pos + zone_size - 1, 10)
 			// False zone for tier 4+ — a single non-overlapping decoy position
 			if(lock_tier >= 4)
 				var/tries = 10
@@ -430,7 +430,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				var/sec_chance = (lock_tier - 3) * 30  // 30% / 60% for tiers 4/5
 				is_security = prob(sec_chance)
 		pins += list(list(
-			"pos"          = 5,
+			"pos"          = 1,
 			"min"          = min_pos,
 			"max"          = max_pos,
 			"set"          = FALSE,
@@ -452,7 +452,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 	// Binding order
 	if(use_stored)
-		bind_order = the_lock.pin_bind_order.Copy()
+		bind_order = stored_bind.Copy()
 	else
 		bind_order = list()
 		for(var/j in 1 to pins.len)
@@ -463,15 +463,15 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			var/list/solution = list()
 			for(var/k in 1 to pins.len)
 				solution += list(list(
-					"true_center"  = pins[k]["min"] + round((zone_size - 1) / 2),
+					"true_center"  = pins[k]["min"] + zone_size / 2,
 					"false_min"    = pins[k]["false_min"],
 					"false_max"    = pins[k]["false_max"],
 					"spool"        = pins[k]["spool"],
 					"security"     = pins[k]["security"],
 					"stack_height" = pins[k]["stack_height"]
 				))
-			the_lock.pin_solution   = solution
-			the_lock.pin_bind_order = bind_order.Copy()
+			the_lock.vars["pin_solution"]   = solution
+			the_lock.vars["pin_bind_order"] = bind_order.Copy()
 
 /**
  * Returns the 1-indexed number of the currently binding pin.
@@ -517,7 +517,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	for(var/list/pin in pins)
 		if(pin["set"])
 			pin["set"]   = FALSE
-			pin["pos"]   = 5
+			pin["pos"]   = 1
 			pin["moves"] = 0
 			pin["decayed"] = TRUE
 			lost++
@@ -821,7 +821,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			// The cylinder isn't pressing on it — it has nothing to catch on.
 			var/binding_check = get_binding_pin()
 			if(binding_check > 0 && current_pin != binding_check)
-				cur_pin["pos"]       = 5
+				cur_pin["pos"]       = 1
 				cur_pin["last_move"] = 0
 				feedback = "The pin springs free — it's loose under current tension. The binding pin is pin [binding_check]."
 				. = TRUE
@@ -837,7 +837,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			// --- False zone check (tier 4+ only) ---
 			if(cur_pin["false_min"] > 0 && pos >= cur_pin["false_min"] && pos <= cur_pin["false_max"])
 				attempts_left--
-				cur_pin["pos"]   = 5
+				cur_pin["pos"]   = 1
 				cur_pin["moves"] = 0
 				// Brief success click then a rejection scrape
 				playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -3)
@@ -907,7 +907,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				if(!(cur_pin["tried"] ~! pos))  // only add to tried if not already there
 					cur_pin["tried"] += pos
 					cur_pin["tried_hints"]["[pos]"] = dist_to_zone
-				cur_pin["pos"]      = 5
+				cur_pin["pos"]      = 1
 				cur_pin["moves"]    = 0  // reset tension after a set attempt
 
 				// Warmer sound for close attempts, colder thud for far misses
@@ -941,7 +941,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 								reset_idx = j
 					if(reset_idx > 0)
 						pins[reset_idx]["set"]     = FALSE
-						pins[reset_idx]["pos"]     = 5
+						pins[reset_idx]["pos"]     = 1
 						pins[reset_idx]["moves"]   = 0
 						pins[reset_idx]["decayed"] = TRUE
 						if(current_pin > pins.len || pins[current_pin]["set"])
@@ -1038,7 +1038,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	for(var/i in 1 to just_set_pin - 1)
 		if(pins[i]["set"] && prob(decay_chance))
 			pins[i]["set"]     = FALSE
-			pins[i]["pos"]     = 5
+			pins[i]["pos"]     = 1
 			pins[i]["moves"]   = 0
 			pins[i]["decayed"] = TRUE
 			// Keep hint/last_dir so the player retains positional memory

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -1,0 +1,584 @@
+/**
+ * lockpick_minigame.dm
+ *
+ * Semi-interactive lockpicking mini-game with full depth mechanics.
+ *
+ * Features:
+ *  1. Pin tension: too many moves on one pin snaps the pick and jams the lock
+ *  2. Pin decay: tier 3+ locks may shake loose a set pin when advancing
+ *  3. Move skill check: low Agility may add extra tension per move
+ *  4. False zones: tier 4+ locks have a deceptive fake "set" position
+ *  5. Specialized picks: tension wrench, bobby pin, electronic pick
+ *  6. Pick degradation: heavy use consumes extra pick durability on end
+ *  7. Locksmith bonus: Agility 8+ widens each pin's correct zone
+ *  8. Sound cues: distinct sounds for hot/cold, false set, and snap
+ *  9. Interruption: dying while picking jams the lock if attempts were made
+ * 10. Jammed locks: use a crowbar to reset a jammed lock mechanism
+ * 11. Partial credit: give_up saves set pins for the next pick attempt
+ */
+
+// =====================================================
+// GLOBAL STATE
+// =====================================================
+
+/// Stores partial pin progress between lockpick attempts. Key = "\ref[target]".
+GLOBAL_LIST_EMPTY(lockpick_partial_states)
+
+// =====================================================
+// LOCKPICK SET VARIANTS
+// =====================================================
+
+/// Standard master set — more uses and better zone widening.
+/obj/item/lockpick_set/master
+	name = "master lockpicking set"
+	desc = "A high-quality set of picks and tension wrenches favored by experienced thieves. More durable than a basic set."
+	icon_state = "basic_lockpick"
+	uses_left = 10
+
+/obj/item/lockpick_set/master/Initialize()
+	. = ..()
+	uses_left = rand(6, initial(src.uses_left))
+
+/// Tension wrench kit — halves pin decay chance. Good for stubborn higher-tier locks.
+/obj/item/lockpick_set/tension_wrench
+	name = "tension wrench kit"
+	desc = "Specialized interchangeable tension wrenches. Keeps pins in place better than a full set, but offers no other advantages."
+	icon_state = "basic_lockpick"
+	uses_left = 8
+
+/obj/item/lockpick_set/tension_wrench/Initialize()
+	. = ..()
+	uses_left = rand(4, initial(src.uses_left))
+
+/// Bobby pin — improvised, fragile, only works on tier 1–2 locks.
+/obj/item/lockpick_set/bobby_pin
+	name = "bobby pin"
+	desc = "A bent hairpin pressed into service as a lockpick. Barely holds together, but it can open simple locks in a pinch."
+	icon_state = "basic_lockpick"
+	uses_left = 3
+
+/obj/item/lockpick_set/bobby_pin/Initialize()
+	. = ..()
+	uses_left = rand(1, initial(src.uses_left))
+
+/// Electronic pick — auto-sets the first pin via vibration. Expensive and fragile.
+/obj/item/lockpick_set/electronic_pick
+	name = "electronic lock pick"
+	desc = "A motorized pick that vibrates to find the first pin's position automatically. Batteries included; discretion sold separately."
+	icon_state = "basic_lockpick"
+	uses_left = 4
+
+/obj/item/lockpick_set/electronic_pick/Initialize()
+	. = ..()
+	uses_left = rand(2, initial(src.uses_left))
+
+// =====================================================
+// LOCKPICKING MINI-GAME DATUM
+// =====================================================
+
+/datum/lockpicking_minigame
+	/// The object being lockpicked (door or locked_box)
+	var/atom/target
+	/// The player performing the lockpick
+	var/mob/user
+	/// The lockpick set being used
+	var/obj/item/lockpick_set/pick
+	/// Lock difficulty tier 1–5
+	var/lock_tier = 1
+	/// User's Luck SPECIAL stat (1–10)
+	var/luck = 5
+	/// User's Agility SPECIAL stat (1–10)
+	var/agility = 5
+	/// Whether a master lockpick is being used
+	var/is_master_pick = FALSE
+	/// Whether a tension wrench is being used (halves pin decay chance)
+	var/is_tension_wrench = FALSE
+	/// Whether a bobby pin is being used (tier cap: 2)
+	var/is_bobby_pin = FALSE
+	/// Whether an electronic pick is being used (auto-sets pin 1)
+	var/is_electronic_pick = FALSE
+
+	/// List of assoc lists per pin:
+	///   "pos", "min", "max", "set", "hint", "last_dir",
+	///   "moves" (tension counter), "false_min", "false_max"
+	var/list/pins = null
+	/// Index of the currently active pin (1-indexed)
+	var/current_pin = 1
+	/// Maximum attempts before game over
+	var/max_attempts = 5
+	/// Remaining failed set_pin attempts
+	var/attempts_left = 5
+	/// Total moves made across all pins (for pick degradation)
+	var/total_moves = 0
+	/// TRUE after the first set_pin attempt is made (for interruption jamming)
+	var/attempt_made = FALSE
+	/// Ref string of target, stored for partial-state timer cleanup
+	var/partial_state_ref = ""
+
+	/// Game phase: "picking", "success", "failed"
+	var/phase = "picking"
+	/// Last feedback message shown in the UI
+	var/feedback = ""
+	/// null = in progress, TRUE = success, FALSE = fail/cancel
+	var/result = null
+	/// Set TRUE when the UI window closes, ending wait()
+	var/closed = FALSE
+
+/datum/lockpicking_minigame/New(atom/the_target, mob/the_user, obj/item/lockpick_set/the_pick, tier)
+	target    = the_target
+	user      = the_user
+	pick      = the_pick
+	lock_tier = clamp(tier, 1, 5)
+	luck      = the_user.special_l
+	if(isliving(the_user))
+		agility = the_user.special_a
+	is_master_pick     = istype(the_pick, /obj/item/lockpick_set/master)
+	is_tension_wrench  = istype(the_pick, /obj/item/lockpick_set/tension_wrench)
+	is_bobby_pin       = istype(the_pick, /obj/item/lockpick_set/bobby_pin)
+	is_electronic_pick = istype(the_pick, /obj/item/lockpick_set/electronic_pick)
+
+	// Bobby pin cannot handle tier 3+ locks
+	if(is_bobby_pin && lock_tier > 2)
+		feedback = "Your bobby pin is too flimsy for this lock — it needs a proper pick."
+		phase = "failed"
+		result = FALSE
+		ui_interact(the_user)
+		addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+		return
+
+	generate_pins()
+
+	// Electronic pick auto-sets pin 1
+	if(is_electronic_pick && pins.len >= 1)
+		pins[1]["set"] = TRUE
+		current_pin = 2
+		feedback = "The electronic pick buzzes — pin 1 located automatically! Handle the rest manually."
+		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
+	else
+		feedback = "Insert your pick and find the correct position for each pin."
+
+	// Load partial save state from a previous give_up, if any
+	var/ref = "\ref[the_target]"
+	if(GLOB.lockpick_partial_states[ref])
+		var/list/saved = GLOB.lockpick_partial_states[ref]
+		GLOB.lockpick_partial_states -= ref
+		for(var/idx in saved)
+			if(idx <= pins.len && !pins[idx]["set"])
+				pins[idx]["set"] = TRUE
+		// Advance current_pin past already-set pins
+		current_pin = 1
+		while(current_pin <= pins.len && pins[current_pin]["set"])
+			current_pin++
+		var/loaded = saved.len
+		if(current_pin <= pins.len)
+			feedback = "Your tension wrench held — [loaded] [loaded == 1 ? "pin" : "pins"] already set. Continue!"
+
+	// Register death signal for interruption handling
+	RegisterSignal(user, COMSIG_MOB_DEATH, PROC_REF(on_user_death))
+
+	ui_interact(the_user)
+
+/datum/lockpicking_minigame/Destroy()
+	if(user && !QDELETED(user))
+		UnregisterSignal(user, COMSIG_MOB_DEATH)
+	SStgui.close_uis(src)
+	return ..()
+
+/**
+ * Generates the pin array based on lock tier, Luck, Agility, and pick type.
+ * Tier 4+ pins also get a false zone — a deceptive fake "correct" position.
+ */
+/datum/lockpicking_minigame/proc/generate_pins()
+	var/num_pins
+	var/base_zone_size
+	switch(lock_tier)
+		if(1)
+			num_pins = 2
+			base_zone_size = 4
+		if(2)
+			num_pins = 3
+			base_zone_size = 3
+		if(3)
+			num_pins = 3
+			base_zone_size = 2
+		if(4)
+			num_pins = 4
+			base_zone_size = 2
+		if(5)
+			num_pins = 5
+			base_zone_size = 1
+
+	// Luck bonus: (1–3) = -1, (4–6) = 0, (7–8) = +1, (9–10) = +2
+	var/luck_bonus      = clamp(round((luck - 4.5) / 2), -1, 2)
+	// Locksmith bonus: Agility 8+ widens zones by 1
+	var/locksmith_bonus = (agility >= 8) ? 1 : 0
+	// Pick bonus: master or electronic pick widens zones by 1
+	var/pick_bonus      = (is_master_pick || is_electronic_pick) ? 1 : 0
+	var/zone_size = clamp(base_zone_size + luck_bonus + locksmith_bonus + pick_bonus, 1, 7)
+
+	// Attempts: base 6, minus tier, plus luck/pick bonuses; minimum 2
+	max_attempts  = max(6 - lock_tier + luck_bonus + (pick_bonus * 2), 2)
+	attempts_left = max_attempts
+
+	pins = list()
+	for(var/i in 1 to num_pins)
+		var/max_start = max(10 - zone_size, 1)
+		var/min_pos   = rand(1, max_start)
+		var/max_pos   = min(min_pos + zone_size - 1, 10)
+		// False zone for tier 4+ — a single non-overlapping decoy position
+		var/false_min = 0
+		var/false_max = 0
+		if(lock_tier >= 4)
+			var/tries = 10
+			while(tries > 0)
+				var/candidate = rand(1, 10)
+				if(candidate < min_pos - 1 || candidate > max_pos + 1)
+					false_min = candidate
+					false_max = candidate
+					break
+				tries--
+		pins += list(list(
+			"pos"       = 5,
+			"min"       = min_pos,
+			"max"       = max_pos,
+			"set"       = FALSE,
+			"hint"      = -1,       // distance from real zone on last attempt; -1 = no attempt
+			"last_dir"  = 0,        // 1 = go up, -1 = go down
+			"moves"     = 0,        // move count for tension mechanic
+			"false_min" = false_min,
+			"false_max" = false_max
+		))
+
+/// Sleeps until the mini-game is fully resolved (closed = TRUE).
+/datum/lockpicking_minigame/proc/wait()
+	while(!closed && !QDELETED(src))
+		if(!QDELETED(user) && user.stat >= UNCONSCIOUS && phase == "picking")
+			on_user_incapacitated()
+		stoplag(1)
+
+/// Called when the user goes unconscious mid-pick (detected in wait loop).
+/datum/lockpicking_minigame/proc/on_user_incapacitated()
+	if(phase != "picking")
+		return
+	phase  = "failed"
+	result = FALSE
+	if(attempt_made)
+		feedback = "You fall unconscious! Your pick jams the lock as you slump."
+		jam_target()
+	else
+		feedback = "You fall unconscious! Your pick slips free of the lock."
+	SStgui.update_uis(src)
+	addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
+
+/// Signal handler — fires when the user mob dies.
+/datum/lockpicking_minigame/proc/on_user_death(mob/living/source, gibbed)
+	SIGNAL_HANDLER
+	if(phase != "picking")
+		return
+	phase  = "failed"
+	result = FALSE
+	if(attempt_made)
+		jam_target()
+		feedback = "You die! Your pick jams the lock as you collapse."
+	else
+		feedback = "You die! Your pick clatters away from the lock."
+	SStgui.update_uis(src)
+	addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
+
+/// Marks the target lock as jammed (requires crowbar to reset).
+/datum/lockpicking_minigame/proc/jam_target()
+	if(istype(target, /obj/structure/simple_door))
+		var/obj/structure/simple_door/D = target
+		D.lockpick_jammed = TRUE
+		D.visible_message(span_warning("The lock of [D] grinds and jams solid!"))
+	else if(istype(target, /obj/item/locked_box))
+		var/obj/item/locked_box/B = target
+		B.lockpick_jammed = TRUE
+		if(!QDELETED(user))
+			to_chat(user, span_warning("The lock jams completely. Use a crowbar to reset the mechanism before trying again."))
+	else if(istype(target, /obj/machinery/door))
+		var/obj/machinery/door/D = target
+		D.lockpick_jammed = TRUE
+		D.visible_message(span_warning("The lock of [D] grinds and jams solid!"))
+
+/**
+ * Saves the current set pins to the global partial state for this target.
+ * Called on give_up so the next pick attempt can resume from here.
+ * The state expires after 60 seconds.
+ */
+/datum/lockpicking_minigame/proc/save_partial_state()
+	var/list/set_indices = list()
+	for(var/i in 1 to pins.len)
+		if(pins[i]["set"])
+			set_indices += i
+	if(set_indices.len)
+		partial_state_ref = "\ref[target]"
+		GLOB.lockpick_partial_states[partial_state_ref] = set_indices
+		addtimer(CALLBACK(src, PROC_REF(expire_partial_state)), 60 SECONDS)
+		var/n = set_indices.len
+		if(!QDELETED(user))
+			to_chat(user, span_notice("You leave your tension wrench in the lock — [n] [n == 1 ? "pin stays" : "pins stay"] set. Continue within 60 seconds to keep your progress."))
+
+/datum/lockpicking_minigame/proc/expire_partial_state()
+	if(partial_state_ref)
+		GLOB.lockpick_partial_states -= partial_state_ref
+
+/**
+ * Finalizes pick durability at the end of the game.
+ * Handles in_use = FALSE, one standard use, plus extra uses from heavy play.
+ * Call this instead of pick.in_use = FALSE + pick.use_pick(user) in calling code.
+ */
+/datum/lockpicking_minigame/proc/finalize(mob/finalize_user)
+	if(QDELETED(pick))
+		return
+	pick.in_use = FALSE
+	// Extra durability drain: every 5 total moves = 1 extra use beyond the standard 1
+	var/extra_uses = max(0, round(total_moves / 5) - 1)
+	for(var/i in 1 to extra_uses)
+		if(QDELETED(pick))
+			break
+		pick.use_pick(finalize_user)
+	if(!QDELETED(pick))
+		pick.use_pick(finalize_user)
+
+/datum/lockpicking_minigame/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Lockpicking", "Lock Picking")
+		ui.open()
+
+/datum/lockpicking_minigame/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/lockpicking_minigame/ui_data(mob/user)
+	var/list/data = list()
+	var/list/pin_data = list()
+	var/pins_set = 0
+	for(var/i in 1 to pins.len)
+		var/list/pin = pins[i]
+		if(pin["set"])
+			pins_set++
+		// Tension: 0–5 scale (moves / 2, clamped)
+		var/tension = clamp(round(pin["moves"] / 2.0), 0, 5)
+		pin_data += list(list(
+			"pos"     = pin["pos"],
+			"set"     = pin["set"],
+			"active"  = (i == current_pin && phase == "picking" && !pin["set"]),
+			"hint"    = pin["hint"],
+			"lastDir" = pin["last_dir"],
+			"tension" = tension
+		))
+	data["pins"]         = pin_data
+	data["pinsSet"]      = pins_set
+	data["currentPin"]   = current_pin
+	data["attemptsLeft"] = attempts_left
+	data["maxAttempts"]  = max_attempts
+	data["phase"]        = phase
+	data["feedback"]     = feedback
+	data["lockTier"]     = lock_tier
+	data["luck"]         = luck
+	data["isMasterPick"] = is_master_pick
+	data["totalPins"]    = pins.len
+	return data
+
+/datum/lockpicking_minigame/ui_close(mob/user)
+	. = ..()
+	closed = TRUE
+	if(isnull(result))
+		result = FALSE
+
+/datum/lockpicking_minigame/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	if(phase != "picking")
+		return
+
+	var/list/cur_pin = pins[current_pin]
+
+	switch(action)
+		if("move_up")
+			// Tension snap check before moving
+			if(cur_pin["moves"] >= 10)
+				snap_pick()
+				return TRUE
+			cur_pin["moves"] = min(cur_pin["moves"] + agility_tension_cost(), 10)
+			if(cur_pin["pos"] < 10)
+				cur_pin["pos"]++
+			total_moves++
+			update_tension_feedback(cur_pin["moves"])
+			. = TRUE
+
+		if("move_down")
+			// Tension snap check before moving
+			if(cur_pin["moves"] >= 10)
+				snap_pick()
+				return TRUE
+			cur_pin["moves"] = min(cur_pin["moves"] + agility_tension_cost(), 10)
+			if(cur_pin["pos"] > 1)
+				cur_pin["pos"]--
+			total_moves++
+			update_tension_feedback(cur_pin["moves"])
+			. = TRUE
+
+		if("set_pin")
+			var/pos = cur_pin["pos"]
+			attempt_made = TRUE
+
+			// --- False zone check (tier 4+ only) ---
+			if(cur_pin["false_min"] > 0 && pos >= cur_pin["false_min"] && pos <= cur_pin["false_max"])
+				attempts_left--
+				cur_pin["pos"]   = 5
+				cur_pin["moves"] = 0
+				// Brief success click then a rejection scrape
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -3)
+				playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 50, TRUE, -4)
+				if(attempts_left <= 0)
+					feedback = "The false groove fools you once too often — you're out of attempts."
+					phase    = "failed"
+					result   = FALSE
+					jam_target()
+					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+				else
+					feedback = "The pin clicks firmly... then springs back out! A false groove — don't be tricked again."
+					if(attempts_left == 1)
+						feedback += " (WARNING: One attempt left!)"
+				. = TRUE
+				return .
+
+			// --- Real zone check ---
+			if(pos >= cur_pin["min"] && pos <= cur_pin["max"])
+				cur_pin["set"]   = TRUE
+				cur_pin["moves"] = 0
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
+				// Advance past already-set pins
+				var/just_set = current_pin
+				current_pin++
+				while(current_pin <= pins.len && pins[current_pin]["set"])
+					current_pin++
+				// Check for pin decay on tier 3+ locks
+				var/decayed = maybe_decay_pins(just_set)
+				if(all_pins_set())
+					phase    = "success"
+					feedback = "The lock clicks open!"
+					result   = TRUE
+					playsound(get_turf(target), 'sound/machines/BoltsUp.ogg', 60, FALSE, -4)
+					addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
+				else if(decayed > 0)
+					current_pin = decayed
+					feedback = "Pin [just_set] set — but pin [decayed] vibrates loose and slips back! Refocus."
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 40, TRUE, -4)
+				else
+					feedback = "Pin [just_set] set. Moving to pin [current_pin]..."
+
+			else
+				// Wrong position — spring back and consume an attempt
+				attempts_left--
+				var/dist_to_zone
+				var/direction
+				if(pos < cur_pin["min"])
+					dist_to_zone = cur_pin["min"] - pos
+					direction    = 1
+				else
+					dist_to_zone = pos - cur_pin["max"]
+					direction    = -1
+				cur_pin["hint"]     = dist_to_zone
+				cur_pin["last_dir"] = direction
+				cur_pin["pos"]      = 5
+				cur_pin["moves"]    = 0  // reset tension after a set attempt
+
+				// Warmer sound for close attempts, colder thud for far misses
+				if(dist_to_zone <= 2)
+					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', 45, TRUE, -4)
+				else
+					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -4)
+
+				var/dir_text = direction == 1 ? "too low — try going higher" : "too high — try going lower"
+				switch(dist_to_zone)
+					if(1)
+						feedback = "Almost! The pin nearly catches — [dir_text] by just one notch!"
+					if(2)
+						feedback = "The pin gives slightly — [dir_text]. Getting warmer..."
+					if(3)
+						feedback = "The pick slips — [dir_text]. Not quite there."
+					else
+						feedback = "The pin springs back hard — [dir_text]. Way off the mark."
+
+				if(attempts_left <= 0)
+					phase    = "failed"
+					result   = FALSE
+					feedback = "You've exhausted your attempts. The lock defeats you."
+					jam_target()
+					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+				else if(attempts_left == 1)
+					feedback += " (WARNING: One attempt left!)"
+			. = TRUE
+
+		if("give_up")
+			save_partial_state()
+			phase    = "failed"
+			feedback = "You carefully withdraw your lockpick."
+			result   = FALSE
+			addtimer(CALLBACK(src, PROC_REF(close_ui)), 0.5 SECONDS)
+			. = TRUE
+
+/**
+ * Returns the tension cost for a single move.
+ * Low Agility has a chance to add extra tension (clumsy handling).
+ */
+/datum/lockpicking_minigame/proc/agility_tension_cost()
+	if(agility <= 3)
+		return prob(30) ? 2 : 1  // Very clumsy: 30% chance of double tension
+	if(agility < 6)
+		return prob(15) ? 2 : 1  // Somewhat clumsy: 15% chance
+	return 1                     // Agility 6+ is always clean
+
+/// Updates feedback with tension warnings when pins are near snapping.
+/datum/lockpicking_minigame/proc/update_tension_feedback(moves)
+	if(moves >= 9)
+		feedback = "WARNING: The pick is about to snap — set it now or you'll jam the lock!"
+	else if(moves >= 6)
+		feedback = "The tension is building... set the pin soon or risk snapping the pick!"
+
+/// Snaps the pick from excessive tension. Jams the lock and destroys the pick.
+/datum/lockpicking_minigame/proc/snap_pick()
+	phase    = "failed"
+	result   = FALSE
+	feedback = "You overtorque the pick — SNAP! The mechanism jams. You'll need a crowbar."
+	playsound(get_turf(target), 'sound/items/Wirecutter.ogg', 100, TRUE, -2)
+	jam_target()
+	if(!QDELETED(pick))
+		qdel(pick)
+	addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
+
+/// Returns TRUE if every pin in the list is set.
+/datum/lockpicking_minigame/proc/all_pins_set()
+	for(var/list/pin in pins)
+		if(!pin["set"])
+			return FALSE
+	return TRUE
+
+/**
+ * After advancing past a freshly-set pin, checks if any previously set pin
+ * vibrates loose (tier 3+ mechanic). Tension wrenches halve the chance.
+ * Returns the index of the decayed pin (0 if none decayed).
+ */
+/datum/lockpicking_minigame/proc/maybe_decay_pins(just_set_pin)
+	if(lock_tier < 3 || just_set_pin <= 1)
+		return 0
+	var/decay_chance = (lock_tier - 2) * 10  // 10% / 20% / 30% for tiers 3/4/5
+	if(is_tension_wrench)
+		decay_chance = round(decay_chance * 0.5)
+	decay_chance = max(0, decay_chance - luck * 2)  // Luck reduces decay
+	for(var/i in 1 to just_set_pin - 1)
+		if(pins[i]["set"] && prob(decay_chance))
+			pins[i]["set"]   = FALSE
+			pins[i]["pos"]   = 5
+			pins[i]["hint"]  = -1
+			pins[i]["moves"] = 0
+			return i
+	return 0
+
+/// Closes the TGUI after a short delay so the player can read the outcome.
+/datum/lockpicking_minigame/proc/close_ui()
+	SStgui.close_uis(src)

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -308,10 +308,11 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	RegisterSignal(user, COMSIG_MOB_ATTACK_HAND, PROC_REF(on_user_hit))
 	RegisterSignal(user, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_user_hit))
 
-	// Overhead icon so bystanders can see the player is lockpicking
+	// Overhead icon so bystanders can see the player is lockpicking.
+	// Alpha scales with picker skill: high perception+agility = subtler (lower alpha).
 	pick_overlay = mutable_appearance('icons/mob/actions/actions_flightsuit.dmi', "flightsuit_lock")
 	pick_overlay.pixel_y = 28
-	pick_overlay.alpha = 195
+	pick_overlay.alpha = clamp(240 - (perception + agility - 2) * 10, 80, 240)
 	var/matrix/M = matrix()
 	M.Scale(0.55)
 	pick_overlay.transform = M
@@ -897,6 +898,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				current_pin = (next_binding > 0) ? next_binding : 1
 				// Check for pin decay on tier 3+ locks
 				var/decayed = maybe_decay_pins(just_set)
+				// Observers with good hearing catch the clean set-click
+				broadcast_pin_attempt(just_set, 0, TRUE)
 				if(all_pins_set())
 					phase    = "success"
 					feedback = "The lock clicks open!"
@@ -937,6 +940,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -14)
 				// Noise alert: failed sets scrape and click. Loud picks alert bystanders.
 				check_noise(dist_to_zone <= 2 ? 1 : 2)
+				// Perception-gated detail for nearby observers
+				broadcast_pin_attempt(current_pin, dist_to_zone, FALSE)
 
 				var/dir_text = direction == 1 ? "too low — try going higher" : "too high — try going lower"
 				switch(dist_to_zone)
@@ -1087,6 +1092,11 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
  */
 /datum/lockpicking_minigame/proc/check_noise(events)
 	var/effective = pick_noise_level * events
+	// Sneaking (walk intent) muffles the sounds of picking
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.m_intent == MOVE_INTENT_WALK)
+			effective = round(effective * 0.5)
 	if(has_lockpick_trait)
 		effective = max(0, effective - 1)  // trained hands are quieter
 	accumulated_noise += effective
@@ -1115,10 +1125,89 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	for(var/mob/M in view(alert_range, get_turf(target)))
 		if(M == user)
 			continue
+		if(!isliving(M))
+			continue
 		var/dist = get_dist(M, get_turf(target))
+		var/obs_perc = M.special_p
+		// Distance degrades effective perception: each tile beyond 2 costs 1 point.
+		// Bobby pin noise (level 3) is obvious enough that perception only matters
+		// at the far edge. Quieter picks require more attentiveness to notice at all.
+		var/perc_needed
+		if(dist <= 2)
+			perc_needed = (pick_noise_level >= 3) ? 1 : 2  // loud = anyone; quiet = basic awareness
+		else
+			perc_needed = (pick_noise_level >= 3) ? 2 : 4  // loud far = needs some awareness; quiet far = needs good senses
+		if(obs_perc < perc_needed)
+			continue
 		var/msg = (dist <= 2) ? near_msg : far_msg
 		if(msg)
 			to_chat(M, msg)
+
+/**
+ * Broadcasts a perception-gated message to observers when the picker makes a
+ * pin set attempt (hit or miss). In real life a trained ear can tell which pin
+ * is being worked and roughly how close the picker is to setting it — the pin
+ * produces a distinct click when it reaches shear-line height, and the quality
+ * of that click changes as the picker homes in on the correct position.
+ *
+ * obs_perception tiers:
+ *   1–3  — Hear a vague metallic click; can't tell anything more.
+ *   4–5  — Can tell whether the picked pin is in the front or back half of the cylinder.
+ *   6–7  — Can identify the pin number by the relative position of the sound
+ *           along the lock body and the effort the picker exerts.
+ *   8–10 — Also distinguishes a "near miss" click (crisp and clean) from a
+ *           "far miss" scrape (dull grind), and hears a firm click on success.
+ *
+ * Range: 4 tiles (must be nearby to hear the subtle sound).
+ */
+/datum/lockpicking_minigame/proc/broadcast_pin_attempt(pin_num, dist_to_zone, was_set)
+	var/turf/T = get_turf(target)
+	var/total_pins = pins ? pins.len : 1
+	// Categorise the pin's position in the cylinder as "front" or "back"
+	// so mid-perception observers get useful directional context.
+	var/half = (pin_num <= round(total_pins / 2)) ? "front" : "back"
+	for(var/mob/M in view(4, T))
+		if(M == user)
+			continue
+		if(!isliving(M))
+			continue
+		var/obs_perc = M.special_p
+		if(obs_perc <= 0)
+			continue
+		// Distance penalty: each tile beyond 2 costs 2 effective perception.
+		// Being right next to the lock (1-2 tiles) costs nothing — you can press
+		// your ear to the door. At 3-4 tiles the sound is muffled by air and
+		// ambient noise; you need sharper senses to pull the same detail.
+		var/obs_dist = get_dist(M, T)
+		if(obs_dist > 2)
+			obs_perc -= (obs_dist - 2) * 2
+		if(obs_perc <= 0)
+			continue
+		// Identifying the picker by name requires line of sight — you need to see
+		// their face. If the observer can't see the user mob, they only know "someone".
+		var/picker_name = (user in view(M)) ? "[user]" : "someone"
+		var/msg
+		if(obs_perc <= 3)
+			// Just the raw sound — no interpretation possible.
+			msg = span_notice("You hear a faint metallic click from [target].")
+		else if(obs_perc <= 5)
+			// Front/back of the lock cylinder.
+			msg = span_notice("You hear a [was_set ? "firm" : "dry"] click from the [half] of [target]'s lock.")
+		else if(obs_perc <= 7)
+			// Pin number identifiable from sound position along the cylinder.
+			if(was_set)
+				msg = span_notice("A crisp click — pin [pin_num] of [total_pins] in [target] just fell into place.")
+			else
+				msg = span_notice("You pick out pin [pin_num] of [total_pins] in [target] — [picker_name] is working it.")
+		else
+			// Near/far miss distinguishable; success is unmistakable.
+			if(was_set)
+				msg = span_notice("A clean, deliberate click — [picker_name] just set pin [pin_num] of [total_pins] in [target].")
+			else if(dist_to_zone <= 2)
+				msg = span_notice("Almost — you hear a near-miss scrape on pin [pin_num] of [total_pins]. [picker_name] is close.")
+			else
+				msg = span_notice("A dull grinding scrape: [picker_name] is far off on pin [pin_num] of [total_pins] in [target].")
+		to_chat(M, msg)
 
 /// Closes the TGUI after a short delay so the player can read the outcome.
 /datum/lockpicking_minigame/proc/close_ui()

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -135,6 +135,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/result = null
 	/// Set to TRUE when the player voluntarily gives up (vs. actual failure)
 	var/gave_up = FALSE
+	/// world.time of last processed ui_act — gates click spam (2-tick cooldown)
+	var/last_action_time = 0
 	/// Whether the user was anchored before lockpicking began (restored on Destroy)
 	var/was_anchored = FALSE
 	/// Noise emitted per failed set attempt: 0=silent, 1=quiet, 2=loud, 3=jangling
@@ -243,7 +245,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		pins[auto_pin]["set"] = TRUE
 		current_pin = get_binding_pin()
 		feedback = "The electronic pick buzzes — pin [auto_pin] auto-set! Pin [current_pin] is now binding."
-		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
+		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -14)
 	else
 		current_pin = get_binding_pin()
 		feedback = "Pin [current_pin] is binding — the cylinder presses on it. Find the right height and set it."
@@ -448,7 +450,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			"security"     = is_security,
 			"decayed"      = FALSE,
 			"overset"      = FALSE,
-			"stack_height" = stack_height
+			"stack_height" = stack_height,
+			"pin_attempts" = 2
 		))
 
 	// Binding order
@@ -481,6 +484,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
  * Returns 0 when all pins are set.
  */
 /datum/lockpicking_minigame/proc/get_binding_pin()
+	if(!pins || !bind_order)
+		return 0
 	for(var/i in 1 to bind_order.len)
 		if(!pins[bind_order[i]]["set"])
 			return bind_order[i]
@@ -522,7 +527,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			pin["moves"] = 0
 			pin["decayed"] = TRUE
 			lost++
-	playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 70, TRUE, -1)
+	playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 70, TRUE, -11)
 	if(lost > 0)
 		feedback = "Your hand cramps! The tension wrench slips — [lost] pin[lost != 1 ? "s" : ""] drop[lost == 1 ? "s" : ""]!"
 	else
@@ -667,31 +672,33 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	var/list/data = list()
 	var/list/pin_data = list()
 	var/pins_set = 0
-	for(var/i in 1 to pins.len)
-		var/list/pin = pins[i]
-		if(pin["set"])
-			pins_set++
-		// Tension: 0–5 scale (moves / 2, clamped)
-		var/tension = clamp(round(pin["moves"] / 2.0), 0, 5)
-		var/list/pin_tried_ui = pin["tried"]
-		pin_data += list(list(
-			"pos"         = pin["pos"],
-			"set"         = pin["set"],
-			"active"      = (i == current_pin && phase == "picking" && !pin["set"]),
-			"hint"        = pin["hint"],
-			"lastDir"     = pin["last_dir"],
-			"lastPos"     = pin["last_pos"],
-			"lastMove"    = pin["last_move"],
-			"tension"     = tension,
-			"tried"       = pin_tried_ui,
-			"triedHints"  = pin["tried_hints"],
-			"spool"       = pin["spool"],
-			"security"    = pin["security"],
-			"decayed"     = pin["decayed"],
-			"overset"     = pin["overset"],
-			"spoolFeel"   = pin["spool"] && !pin["set"] && pin["pos"] >= pin["min"] && pin["pos"] <= pin["max"] && pin["last_move"] == -1,
-			"stackHeight" = pin["stack_height"]
-		))
+	if(pins)
+		for(var/i in 1 to pins.len)
+			var/list/pin = pins[i]
+			if(pin["set"])
+				pins_set++
+			// Tension: 0–5 scale (moves / 2, clamped)
+			var/tension = clamp(round(pin["moves"] / 2.0), 0, 5)
+			var/list/pin_tried_ui = pin["tried"]
+			pin_data += list(list(
+				"pos"         = pin["pos"],
+				"set"         = pin["set"],
+				"active"      = (i == current_pin && phase == "picking" && !pin["set"]),
+				"hint"        = pin["hint"],
+				"lastDir"     = pin["last_dir"],
+				"lastPos"     = pin["last_pos"],
+				"lastMove"    = pin["last_move"],
+				"tension"     = tension,
+				"tried"       = pin_tried_ui,
+				"triedHints"  = pin["tried_hints"],
+				"spool"       = pin["spool"],
+				"security"    = pin["security"],
+				"decayed"     = pin["decayed"],
+				"overset"     = pin["overset"],
+				"spoolFeel"   = pin["spool"] && !pin["set"] && pin["pos"] >= pin["min"] && pin["pos"] <= pin["max"] && pin["last_move"] == -1,
+				"stackHeight" = pin["stack_height"],
+				"pinAttempts" = pin["pin_attempts"]
+			))
 	data["pins"]         = pin_data
 	data["pinsSet"]      = pins_set
 	data["currentPin"]   = current_pin
@@ -703,7 +710,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	data["luck"]         = luck
 	data["perception"]    = perception
 	data["isMasterPick"]  = is_master_pick
-	data["totalPins"]     = pins.len
+	data["totalPins"]     = pins ? pins.len : 0
 	data["isDark"]        = dark_penalty
 	data["isHurt"]        = pain_penalty
 	data["wearingGloves"] = glove_penalty
@@ -731,6 +738,9 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 		return
 	if(phase != "picking")
 		return
+	if(world.time - last_action_time < 2)  // 2-tick (0.2s) cooldown — prevents click spam consuming multiple attempts
+		return
+	last_action_time = world.time
 
 	// Guard: after non-linear play current_pin may sit past the end of the list.
 	var/list/cur_pin = (current_pin >= 1 && current_pin <= pins.len) ? pins[current_pin] : null
@@ -786,7 +796,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			if(cur_pin["spool"] && !cur_pin["set"] && !cur_pin["overset"] \
 				&& cur_pin["pos"] >= cur_pin["min"] && cur_pin["pos"] <= cur_pin["max"] \
 				&& cur_pin["last_move"] != 1)
-				playsound(get_turf(target), 'sound/machines/button1.ogg', 25, FALSE, -6)
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 25, FALSE, -15)
 				if(is_binding)
 					feedback = "The cylinder gives slightly... then catches. Something's different about this pin."
 			cur_pin["last_move"] = -1
@@ -840,7 +850,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				cur_pin["pos"]   = 1
 				cur_pin["moves"] = 0
 				feedback = "The pick's frequency shifts — the electronics detect a false groove! No attempt wasted."
-				playsound(get_turf(target), 'sound/machines/button1.ogg', 30, FALSE, -6)
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 30, FALSE, -15)
 				. = TRUE
 				return .
 
@@ -850,8 +860,8 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				cur_pin["pos"]   = 1
 				cur_pin["moves"] = 0
 				// Brief success click then a rejection scrape
-				playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -3)
-				playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 50, TRUE, -4)
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -14)
+				playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 50, TRUE, -14)
 				if(attempts_left <= 0)
 					feedback = "The false groove fools you once too often — you're out of attempts."
 					phase    = "failed"
@@ -873,14 +883,14 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					cur_pin["pos"]   = max(cur_pin["min"] - 2, 1)
 					cur_pin["moves"] = 0
 					cur_pin["last_move"] = 0
-					playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -3)
-					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 45, TRUE, -4)
+					playsound(get_turf(target), 'sound/machines/button1.ogg', 40, FALSE, -14)
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 45, TRUE, -14)
 					feedback = "The pin clicks... then springs back! It's a spool pin — approach from lower positions (move up into the zone)."
 					. = TRUE
 					return .
 				cur_pin["set"]   = TRUE
 				cur_pin["moves"] = 0
-				playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -14)
 				var/just_set = current_pin
 				// Advance focus to the next binding pin in the shuffled bind_order
 				var/next_binding = get_binding_pin()
@@ -891,18 +901,18 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					phase    = "success"
 					feedback = "The lock clicks open!"
 					result   = TRUE
-					playsound(get_turf(target), 'sound/machines/BoltsUp.ogg', 60, FALSE, -4)
+					playsound(get_turf(target), 'sound/machines/BoltsUp.ogg', 60, FALSE, -12)
 					addtimer(CALLBACK(src, PROC_REF(close_ui)), 1.5 SECONDS)
 				else if(decayed > 0)
 					current_pin = decayed
 					feedback = "Pin [just_set] set — but pin [decayed] vibrates loose and slips back! Refocus."
-					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 40, TRUE, -4)
+					playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 40, TRUE, -14)
 				else
 					feedback = "Pin [just_set] set. Moving to pin [current_pin]..."
 
 			else
-				// Wrong position — spring back and consume an attempt
-				attempts_left--
+				// Wrong position — spring back and consume this pin's one allowed attempt
+				cur_pin["pin_attempts"]--
 				var/dist_to_zone
 				var/direction
 				if(pos < cur_pin["min"])
@@ -922,9 +932,9 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 
 				// Warmer sound for close attempts, colder thud for far misses
 				if(dist_to_zone <= 2)
-					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', 45, TRUE, -4)
+					playsound(get_turf(target), 'sound/items/screwdriver2.ogg', 45, TRUE, -14)
 				else
-					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -4)
+					playsound(get_turf(target), 'sound/items/screwdriver.ogg', 55, TRUE, -14)
 				// Noise alert: failed sets scrape and click. Loud picks alert bystanders.
 				check_noise(dist_to_zone <= 2 ? 1 : 2)
 
@@ -957,10 +967,10 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 						if(current_pin > pins.len || pins[current_pin]["set"])
 							current_pin = reset_idx
 						feedback += " The serrated pin catches — pin [reset_idx] jolts loose!"
-						playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 60, TRUE, -3)
+						playsound(get_turf(target), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 60, TRUE, -12)
 
 				// Bobby pin breakage: 25% chance to snap on each failed attempt
-				if(is_bobby_pin && attempts_left > 0 && prob(25))
+				if(is_bobby_pin && prob(25))
 					feedback += " The bobby pin snaps!"
 					phase  = "failed"
 					result = FALSE
@@ -969,14 +979,14 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
 					. = TRUE
 					return .
-				if(attempts_left <= 0)
+				if(cur_pin["pin_attempts"] <= 0)
 					phase    = "failed"
 					result   = FALSE
-					feedback = "You've exhausted your attempts. The lock defeats you."
+					feedback = "You've botched pin [current_pin] twice — the cylinder slams shut."
 					jam_target()
 					addtimer(CALLBACK(src, PROC_REF(close_ui)), 2 SECONDS)
-				else if(attempts_left == 1)
-					feedback += " (WARNING: One attempt left!)"
+				else if(cur_pin["pin_attempts"] == 1)
+					feedback += " (WARNING: Last chance on this pin!)"
 			. = TRUE
 
 		if("give_up")
@@ -1017,7 +1027,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	phase    = "failed"
 	result   = FALSE
 	feedback = "You overtorque the pick — SNAP! A fragment is stuck in the lock. Fish it out before trying again."
-	playsound(get_turf(target), 'sound/items/Wirecutter.ogg', 100, TRUE, -2)
+	playsound(get_turf(target), 'sound/items/Wirecutter.ogg', 100, TRUE, -10)
 	// Spawn pick fragment — physically blocks the lock until removed
 	var/obj/item/pick_fragment/frag = new(get_turf(target))
 	frag.stuck_in = target

--- a/code/modules/lockpicking/lockpick_minigame.dm
+++ b/code/modules/lockpicking/lockpick_minigame.dm
@@ -237,11 +237,12 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	if(penalty_warnings.len)
 		to_chat(the_user, span_warning("WARNING: [english_list(penalty_warnings)] will make this harder."))
 
-	// Electronic pick auto-sets pin 1
+	// Electronic pick auto-sets the first binding pin (vibration finds the most-stressed tumbler)
 	if(is_electronic_pick && pins.len >= 1)
-		pins[1]["set"] = TRUE
+		var/auto_pin = bind_order[1]
+		pins[auto_pin]["set"] = TRUE
 		current_pin = get_binding_pin()
-		feedback = "The electronic pick buzzes — pin 1 set! Pin [current_pin] is now binding."
+		feedback = "The electronic pick buzzes — pin [auto_pin] auto-set! Pin [current_pin] is now binding."
 		playsound(get_turf(target), 'sound/machines/button1.ogg', 50, FALSE, -3)
 	else
 		current_pin = get_binding_pin()
@@ -422,7 +423,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				var/spool_chance = (lock_tier - 2) * 20  // 20% / 40% / 60% for tiers 3/4/5
 				if(prob(spool_chance))
 					is_spool = TRUE
-					min_pos = max(min_pos, 3)  // ensure room to approach from below
+					min_pos = max(min_pos, 2)  // ensure one position below for upward approach
 					max_pos = min(min_pos + zone_size - 1, 10)
 			// Security pins (tier 4+): a failed set attempt jars loose a neighboring set pin.
 			// A pin cannot be both spool and security.
@@ -741,7 +742,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			// Non-binding pins feel loose — no cylinder pressure, no pick stress
 			var/up_cost = is_binding ? agility_tension_cost() : 0
 			// Electronic pick stall only applies to the binding pin
-			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(15))
+			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(10))
 				up_cost++
 				feedback = "The pick's motor stutters — extra tension!"
 			// Snap only possible under cylinder pressure
@@ -766,7 +767,7 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 			var/binding_num = get_binding_pin()
 			var/is_binding  = (binding_num > 0 && current_pin == binding_num)
 			var/down_cost   = is_binding ? agility_tension_cost() : 0
-			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(15))
+			if(is_binding && is_electronic_pick && current_pin >= 3 && prob(10))
 				down_cost++
 				feedback = "The pick's motor stutters — extra tension!"
 			if(is_binding && cur_pin["moves"] >= 10)
@@ -833,6 +834,15 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 				return .
 			var/pos = cur_pin["pos"]
 			attempt_made = TRUE
+
+			// Electronic pick: vibration sensors detect false grooves before committing
+			if(is_electronic_pick && cur_pin["false_min"] > 0 && pos >= cur_pin["false_min"] && pos <= cur_pin["false_max"])
+				cur_pin["pos"]   = 1
+				cur_pin["moves"] = 0
+				feedback = "The pick's frequency shifts — the electronics detect a false groove! No attempt wasted."
+				playsound(get_turf(target), 'sound/machines/button1.ogg', 30, FALSE, -6)
+				. = TRUE
+				return .
 
 			// --- False zone check (tier 4+ only) ---
 			if(cur_pin["false_min"] > 0 && pos >= cur_pin["false_min"] && pos <= cur_pin["false_max"])
@@ -1058,25 +1068,32 @@ GLOBAL_LIST_EMPTY(lockpick_partial_states)
 	if(accumulated_noise < 5)
 		return
 	accumulated_noise = 0
-	// Range and message scale with how loud the pick type is
+	// Range and message scale with noise level; closer listeners get more precise alerts
 	var/alert_range
-	var/sound_msg
+	var/near_msg  // within 2 tiles — source is identifiable
+	var/far_msg   // at the outer edge — vague, hard to place
 	switch(pick_noise_level)
-		if(3)  // bobby pin
-			alert_range = 8
-			sound_msg = "There's loud metallic scraping coming from [target]!"
-		if(2)
+		if(3)  // bobby pin — jangling metal, hard to miss
 			alert_range = 5
-			sound_msg = "You hear suspicious scraping near [target]."
+			near_msg = span_warning("There's loud metallic scraping coming from [target]!")
+			far_msg  = span_notice("You catch a distant scraping sound.")
+		if(2)
+			alert_range = 3
+			near_msg = span_warning("You hear suspicious scraping near [target].")
+			far_msg  = span_notice("You barely make out a faint click nearby.")
 		if(1)
 			alert_range = 3
-			sound_msg = "There's a faint metallic click from [target]."
+			near_msg = span_notice("There's a faint metallic click from [target].")
+			far_msg  = null  // at the edge, too quiet to be distinct
 		else  // master pick: silent, no alert
 			return
 	for(var/mob/M in view(alert_range, get_turf(target)))
 		if(M == user)
 			continue
-		to_chat(M, span_warning(sound_msg))
+		var/dist = get_dist(M, get_turf(target))
+		var/msg = (dist <= 2) ? near_msg : far_msg
+		if(msg)
+			to_chat(M, msg)
 
 /// Closes the TGUI after a short delay so the player can read the outcome.
 /datum/lockpicking_minigame/proc/close_ui()

--- a/fallout/obj/door_keys.dm
+++ b/fallout/obj/door_keys.dm
@@ -90,6 +90,15 @@
 	layer = 100
 	var/open = FALSE
 	var/id = null
+	/// Difficulty tier used by the lockpicking minigame — mapper-settable per door.
+	var/lock_tier = 2
+	/// Mirrors !open so the lockpicking system can read a unified 'locked' var.
+	var/locked = TRUE
+	/// Set TRUE when the lock is bypassed by lockpicking — cleared when re-locked with a key.
+	var/tampered = FALSE
+	/// Persistent tumbler solution and binding order — managed by the minigame.
+	var/list/pin_solution = null
+	var/list/pin_bind_order = null
 
 /obj/item/lock/New(location)
 	..()
@@ -135,6 +144,9 @@
 
 /obj/item/lock/proc/toggle()
 	open = !open
+	locked = !open
+	if(!open)  // just re-locked with a key
+		tampered = FALSE
 	update_icon()
 
 /obj/item/lock/update_icon()

--- a/fallout/obj/structures/simple_door.dm
+++ b/fallout/obj/structures/simple_door.dm
@@ -20,6 +20,9 @@
 	explosion_block = 0.5
 	var/can_hold_padlock = FALSE
 	var/obj/item/lock_construct/padlock
+	var/lock_tier = 2
+	/// Set TRUE when a lockpick snap or exhausted attempts jams the mechanism.
+	var/lockpick_jammed = FALSE
 	var/door_type = "house"
 	var/base_opacity = TRUE
 	var/manual_opened = 0
@@ -116,6 +119,14 @@
 
 /* can crowbar off a lock, to force a door open. This is overriden in airlock so shouldnt be an issue */
 /obj/structure/simple_door/proc/try_to_crowbar(obj/item/I, mob/user)
+	// Clear a jammed lock first
+	if(lockpick_jammed)
+		lockpick_jammed = FALSE
+		user.visible_message(
+			span_notice("[user] pries the jammed lock mechanism loose on [src]."),
+			span_notice("You pry the jammed mechanism loose — the lock resets.")
+		)
+		return
 	if(padlock) /* attempt to pry the lock off */
 		if(padlock.pry_off(user,src))
 			qdel(padlock)
@@ -191,6 +202,9 @@
 			return
 		else
 			return padlock.check_key(I,user)
+	if(istype(I, /obj/item/lockpick_set))
+		try_to_lockpick(I, user)
+		return TRUE
 	if(user.a_intent == INTENT_HARM)
 //		if(padlock)
 //			add_logs(user, src, "attacked", src)
@@ -198,6 +212,44 @@
 	attack_hand(user)
 
 
+
+/obj/structure/simple_door/proc/try_to_lockpick(obj/item/lockpick_set/picking, mob/user)
+	if(!padlock || !padlock.locked)
+		to_chat(user, span_warning("There's no locked lock to pick."))
+		return FALSE
+	if(lockpick_jammed)
+		to_chat(user, span_warning("The lock is jammed solid. Use a crowbar to reset the mechanism first."))
+		return FALSE
+	if(picking.in_use)
+		to_chat(user, span_warning("Your lockpick is already in use."))
+		return FALSE
+
+	picking.in_use = TRUE
+
+	user.visible_message(
+		"[user] begins picking a lock!",
+		"You begin raking the tumblers...",
+		"You hear an odd mechanical picking and scraping sound."
+	)
+	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
+
+	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier)
+	game.wait()
+
+	var/success = game.result
+	game.finalize(user)
+	if(!QDELETED(game))
+		qdel(game)
+
+	if(success)
+		if(QDELETED(src) || !padlock)
+			return
+		user.show_message(span_green("You feel the lock give way. It's open!"))
+		padlock.locked = FALSE
+		SwitchState(TRUE)
+		return TRUE
+	else if(lockpick_jammed)
+		to_chat(user, span_warning("The lock jammed! Use a crowbar to reset [src]'s mechanism."))
 
 /obj/structure/simple_door/proc/TryToSwitchState(atom/user, animate)
 	if(moving)

--- a/fallout/obj/structures/simple_door.dm
+++ b/fallout/obj/structures/simple_door.dm
@@ -141,6 +141,9 @@
 		)
 		return
 	if(padlock) /* attempt to pry the lock off */
+		if(padlock.locked)
+			to_chat(user, span_warning("The padlock is locked — you can't pry it off while it's locked."))
+			return
 		if(padlock.pry_off(user,src))
 			qdel(padlock)
 			padlock = null

--- a/fallout/obj/structures/simple_door.dm
+++ b/fallout/obj/structures/simple_door.dm
@@ -37,9 +37,12 @@
 	var/closing_time = 4
 	var/autoclose = 5 SECONDS
 
-/obj/structure/simple_door/Initialize()
+/obj/structure/simple_door/examine(mob/user)
 	. = ..()
-	icon_state = door_type
+	if(padlock && padlock.tampered)
+		. += span_warning("The lock looks like it's been worked — someone forced their way through.")
+
+
 
 
 /obj/structure/simple_door/Destroy()
@@ -121,6 +124,16 @@
 /obj/structure/simple_door/proc/try_to_crowbar(obj/item/I, mob/user)
 	// Clear a jammed lock first
 	if(lockpick_jammed)
+		user.visible_message(
+			span_notice("[user] starts working [src]'s jammed lock mechanism loose."),
+			span_notice("You start working the jammed mechanism loose..."),
+			span_notice("You hear a grinding scrape of metal from [src].")
+		)
+		playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 60, TRUE, ignore_walls = FALSE)
+		if(!do_after(user, 35, target = src))
+			return
+		if(QDELETED(src))
+			return
 		lockpick_jammed = FALSE
 		user.visible_message(
 			span_notice("[user] pries the jammed lock mechanism loose on [src]."),
@@ -233,10 +246,12 @@
 	)
 	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
 
-	var/datum/lockpicking_minigame/game = new(src, user, picking, lock_tier)
+	// Use the physical lock's tier — it determines how complex the mechanism is.
+	var/datum/lockpicking_minigame/game = new(src, user, picking, padlock.lock_tier, padlock)
 	game.wait()
 
 	var/success = game.result
+	var/gave_up = game.gave_up
 	game.finalize(user)
 	if(!QDELETED(game))
 		qdel(game)
@@ -246,10 +261,38 @@
 			return
 		user.show_message(span_green("You feel the lock give way. It's open!"))
 		padlock.locked = FALSE
+		padlock.tampered = TRUE
+		// For old-style /obj/item/lock (faction doors): also flip open state and refresh icon.
+		if(istype(padlock, /obj/item/lock))
+			var/obj/item/lock/L = padlock
+			L.open = TRUE
+			L.update_icon()
+		// Clear stored solution — lock will get a fresh combination if re-locked.
+		padlock.pin_solution    = null
+		padlock.pin_bind_order  = null
 		SwitchState(TRUE)
 		return TRUE
-	else if(lockpick_jammed)
-		to_chat(user, span_warning("The lock jammed! Use a crowbar to reset [src]'s mechanism."))
+	else
+		// After failure the pins are jostled — they must be physically walked back
+		// into position before a new attempt can begin (mirrors pry_off behaviour).
+		// Voluntary give-up withdraws cleanly — no reset needed.
+		if(!QDELETED(src) && padlock && !lockpick_jammed && !gave_up)
+			user.visible_message(
+				"[user] starts working the pins in [src]'s lock back into position.",
+				"You start working the pins back into position...",
+				"You hear a careful series of soft clicks from [src]."
+			)
+			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 50, TRUE, ignore_walls = FALSE)
+			if(!do_after(user, 50, target = src))
+				return FALSE
+			if(QDELETED(src) || !padlock)
+				return FALSE
+			user.visible_message(
+				span_notice("[user] finishes resetting [src]'s lock mechanism."),
+				span_notice("The mechanism is reset. Try again."),
+			)
+		if(lockpick_jammed)
+			to_chat(user, span_warning("The lock jammed! Use a crowbar to reset [src]'s mechanism."))
 
 /obj/structure/simple_door/proc/TryToSwitchState(atom/user, animate)
 	if(moving)

--- a/fallout/obj/structures/simple_door.dm
+++ b/fallout/obj/structures/simple_door.dm
@@ -23,6 +23,8 @@
 	var/lock_tier = 2
 	/// Set TRUE when a lockpick snap or exhausted attempts jams the mechanism.
 	var/lockpick_jammed = FALSE
+	/// Transient flag: set by try_to_lockpick before opening so Open() can muffle the door-open sound.
+	var/lockpick_muffled = FALSE
 	var/door_type = "house"
 	var/base_opacity = TRUE
 	var/manual_opened = 0
@@ -86,7 +88,12 @@
 	return
 
 /obj/structure/simple_door/proc/Open(animate)
-	playsound(src.loc, open_sound, 30, 0, 0)
+	// When triggered by a lockpick, muffle the open sound to a short range.
+	if(lockpick_muffled)
+		lockpick_muffled = FALSE
+		playsound(src.loc, open_sound, 25, 0, -13)
+	else
+		playsound(src.loc, open_sound, 30, 0, 0)
 	if(animate)
 		moving = 1
 		flick("[door_type]opening", src)
@@ -247,7 +254,7 @@
 		"You begin raking the tumblers...",
 		"You hear an odd mechanical picking and scraping sound."
 	)
-	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, ignore_walls = FALSE)
+	playsound(get_turf(src), pick('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg'), 25, TRUE, -9)
 
 	// Use the physical lock's tier — it determines how complex the mechanism is.
 	var/datum/lockpicking_minigame/game = new(src, user, picking, padlock.lock_tier, padlock)
@@ -273,7 +280,9 @@
 		// Clear stored solution — lock will get a fresh combination if re-locked.
 		padlock.pin_solution    = null
 		padlock.pin_bind_order  = null
+		lockpick_muffled = TRUE   // door-open sound should be muffled after a quiet lockpick
 		SwitchState(TRUE)
+		lockpick_muffled = FALSE  // safety reset
 		return TRUE
 	else
 		// After failure the pins are jostled — they must be physically walked back
@@ -285,7 +294,7 @@
 				"You start working the pins back into position...",
 				"You hear a careful series of soft clicks from [src]."
 			)
-			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 50, TRUE, ignore_walls = FALSE)
+			playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 40, TRUE, -10)
 			if(!do_after(user, 50, target = src))
 				return FALSE
 			if(QDELETED(src) || !padlock)

--- a/hailmary.dme
+++ b/hailmary.dme
@@ -2441,6 +2441,7 @@
 #include "code\modules\lighting\lighting_setup.dm"
 #include "code\modules\lighting\lighting_source.dm"
 #include "code\modules\lighting\lighting_turf.dm"
+#include "code\modules\lockpicking\lockpick_minigame.dm"
 #include "code\modules\mafia\_defines.dm"
 #include "code\modules\mafia\controller.dm"
 #include "code\modules\mafia\map_pieces.dm"

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -175,31 +175,11 @@ h1.alert, h2.alert		{color: #000000;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .singing				{font-family: "Trebuchet MS", cursive, sans-serif; font-style: italic;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.velvet					{color: #660015; 	font-weight: bold; animation: velvet 5000ms infinite;}
-@keyframes velvet {
-	0% { color: #400020; }
-	40% { color: #FF0000; }
-	50% { color: #FF8888; }
-	60% { color: #FF0000; }
-	100% { color: #400020; }
-}
+.velvet					{color: #660015; 	font-weight: bold;}
 
-.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
-	@keyframes hypnocolor {
-		0%		{color: #0d0d0d;}
-		25%		{color: #410194;}
-		50%		{color: #7f17d8;}
-		75%		{color: #410194;}
-		100%	{color: #3bb5d3;}
-}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold;}
 
-
-.phobia			{color: #dd0000;	font-weight: bold;	animation: phobia 750ms infinite;}
-	@keyframes phobia {
-		0%		{color: #0d0d0d;}
-		50%		{color: #dd0000;}
-		100%	{color: #0d0d0d;}
-}
+.phobia			{color: #dd0000;	font-weight: bold;}
 
 .icon					{height: 1em;	width: auto;}
 

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -1,0 +1,259 @@
+/**
+ * Lockpicking.js — Semi-interactive lockpicking mini-game UI.
+ *
+ * Shows a set of lock pins. The player moves each pin up or down
+ * and presses "Set Pin" to try to lock it at the correct height.
+ * After a failed attempt each pin shows a heat indicator (direction
+ * arrow + "One notch off!" / "Getting close" / "Way off") so the
+ * player can narrow in over successive tries.
+ */
+
+import { useBackend } from '../backend';
+import { Box, Button, LabeledList, NoticeBox, ProgressBar, Section } from '../components';
+import { Window } from '../layouts';
+
+const TIER_LABELS = ['', 'Very Easy', 'Easy', 'Average', 'Hard', 'Very Hard'];
+
+/** Returns display info for the heat indicator based on distance from zone. */
+const hintInfo = (hint, lastDir) => {
+  const arrow = lastDir > 0 ? '▲' : lastDir < 0 ? '▼' : '';
+  if (hint < 0) return null; // no attempt yet
+  if (hint === 1) return { color: '#ff5722', label: 'One notch off!', arrow };
+  if (hint === 2) return { color: '#ff9800', label: 'Getting close', arrow };
+  if (hint === 3) return { color: '#42a5f5', label: 'Not quite', arrow };
+  return { color: '#1565c0', label: 'Way off', arrow };
+};
+
+/** Returns display info for pick tension (moves accumulated on current pin). */
+const tensionInfo = (tension) => {
+  if (!tension || tension <= 0) return null;
+  if (tension <= 2) return { color: '#ffee58', label: 'Building...' };
+  if (tension <= 4) return { color: '#ff9800', label: 'Careful!' };
+  return { color: '#f44336', label: 'ABOUT TO SNAP!' };
+};
+
+export const Lockpicking = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    pins = [],
+    pinsSet = 0,
+    attemptsLeft,
+    maxAttempts,
+    phase,
+    feedback,
+    lockTier,
+    luck,
+    isMasterPick,
+    totalPins,
+  } = data;
+
+  const isFinished = phase !== 'picking';
+  const activePinIndex = pins.findIndex(p => p.active);
+  const activePin = activePinIndex !== -1 ? pins[activePinIndex] : null;
+
+  return (
+    <Window
+      theme="fallout"
+      title="Lock Picking"
+      width={500}
+      height={520}>
+      <Window.Content>
+
+        {/* ── Status ───────────────────────────────────────── */}
+        <Section title="Lock Status">
+          <LabeledList>
+            <LabeledList.Item label="Difficulty">
+              <ProgressBar
+                value={lockTier}
+                minValue={0}
+                maxValue={5}
+                ranges={{
+                  good: [-Infinity, 1.5],
+                  average: [1.5, 3.5],
+                  bad: [3.5, Infinity],
+                }}>
+                {TIER_LABELS[lockTier] || 'Unknown'}
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item label="Luck">
+              <ProgressBar
+                value={luck}
+                minValue={0}
+                maxValue={10}
+                ranges={{
+                  bad: [-Infinity, 3],
+                  average: [3, 6],
+                  good: [6, Infinity],
+                }}>
+                {luck} / 10{isMasterPick ? ' — Master Pick' : ''}
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item label="Attempts Left">
+              <ProgressBar
+                value={attemptsLeft}
+                minValue={0}
+                maxValue={maxAttempts}
+                ranges={{
+                  bad: [-Infinity, 2],
+                  average: [2, 4],
+                  good: [4, Infinity],
+                }}>
+                {attemptsLeft} / {maxAttempts}
+              </ProgressBar>
+            </LabeledList.Item>
+          </LabeledList>
+        </Section>
+
+        {/* ── Feedback ─────────────────────────────────────── */}
+        <NoticeBox
+          success={phase === 'success'}
+          danger={phase === 'failed'}>
+          {feedback}
+        </NoticeBox>
+
+        {/* ── Pins ─────────────────────────────────────────── */}
+        <Section title={`Pins — ${pinsSet} / ${totalPins} Set`}>
+          <Box style={{ 'display': 'flex', 'justify-content': 'center', 'align-items': 'flex-start', 'flex-wrap': 'wrap' }}>
+            {pins.map((pin, i) => {
+              const heat = hintInfo(pin.hint, pin.lastDir);
+              return (
+                <Box
+                  key={i}
+                  mx="5px"
+                  textAlign="center"
+                  style={{
+                    'border': pin.active
+                      ? '1px solid #ffaa00'
+                      : pin.set
+                        ? '1px solid #00c853'
+                        : '1px solid #333',
+                    'border-radius': '4px',
+                    'padding': '4px 4px 6px 4px',
+                    'background': pin.active ? 'rgba(255,170,0,0.06)' : 'transparent',
+                    'min-width': '48px',
+                  }}>
+
+                  {/* Pin label */}
+                  <Box
+                    mb="3px"
+                    fontSize="11px"
+                    bold
+                    color={pin.set ? 'good' : pin.active ? 'yellow' : 'grey'}>
+                    PIN {i + 1}
+                  </Box>
+
+                  {/* Segments — column-reverse so pos 1 = bottom */}
+                  <Box style={{
+                    'display': 'flex',
+                    'flex-direction': 'column-reverse',
+                    'align-items': 'center',
+                    'gap': '2px',
+                  }}>
+                    {Array.from({ length: 10 }, (_, si) => {
+                      const segPos = si + 1;
+                      const isCurrent = !pin.set && pin.pos === segPos;
+                      let bg;
+                      if (pin.set) {
+                        bg = '#00c853';
+                      } else if (isCurrent && pin.active) {
+                        bg = '#ffaa00';
+                      } else if (isCurrent) {
+                        bg = '#3a7abf';
+                      } else {
+                        bg = '#1e1e1e';
+                      }
+                      return (
+                        <Box
+                          key={si}
+                          style={{
+                            'width': '34px',
+                            'height': '11px',
+                            'background-color': bg,
+                            'border': isCurrent && pin.active
+                              ? '1px solid #ffcc00'
+                              : '1px solid #2e2e2e',
+                            'border-radius': '2px',
+                          }}
+                        />
+                      );
+                    })}
+                  </Box>
+
+                  {/* Position label */}
+                  <Box mt="3px" fontSize="11px">
+                    {pin.set ? (
+                      <Box color="good" bold>✓</Box>
+                    ) : pin.active ? (
+                      <Box color="label">{pin.pos} / 10</Box>
+                    ) : (
+                      <Box color="grey">—</Box>
+                    )}
+                  </Box>
+
+                  {/* Heat hint + tension warning — only shown on active pin */}
+                  <Box style={{ 'min-height': '42px' }}>
+                    {pin.active && heat && (
+                      <Box mt="3px" fontSize="11px" color={heat.color} bold>
+                        {heat.arrow} {heat.label}
+                      </Box>
+                    )}
+                    {pin.active && tensionInfo(pin.tension) && (
+                      <Box mt="2px" fontSize="10px" color={tensionInfo(pin.tension).color} bold>
+                        ⚠ {tensionInfo(pin.tension).label}
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        </Section>
+
+        {/* ── Controls ─────────────────────────────────────── */}
+        {!isFinished && activePin !== null && (
+          <Section>
+            <Box textAlign="center">
+              <Button
+                icon="arrow-up"
+                mr={1}
+                onClick={() => act('move_up')}>
+                Move Up
+              </Button>
+              <Button
+                icon="arrow-down"
+                mr={1}
+                onClick={() => act('move_down')}>
+                Move Down
+              </Button>
+              <Button
+                icon="check"
+                color="good"
+                mr={1}
+                onClick={() => act('set_pin')}>
+                Set Pin
+              </Button>
+              <Button
+                icon="times"
+                color="bad"
+                onClick={() => act('give_up')}>
+                Give Up
+              </Button>
+            </Box>
+          </Section>
+        )}
+
+        {isFinished && (
+          <Section textAlign="center">
+            <Box
+              color={phase === 'success' ? 'good' : 'bad'}
+              fontSize="14px"
+              bold>
+              {phase === 'success' ? '— Lock Opened —' : '— Lock Picking Failed —'}
+            </Box>
+          </Section>
+        )}
+
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -21,6 +21,12 @@ import { Box, Button, LabeledList, NoticeBox, ProgressBar, Section } from '../co
 import { Window } from '../layouts';
 
 const TIER_LABELS = ['', 'Very Easy', 'Easy', 'Average', 'Hard', 'Very Hard'];
+const PICK_WEAR_LABELS = [
+  '',
+  'Light wear \u2014 feel is slightly muffled',
+  'Worn \u2014 zone estimates less precise',
+  'Nearly spent \u2014 feel is very rough',
+];
 
 // CSS animation for the active pin glow pulse (injected via a <style> tag).
 const PIN_PULSE_CSS = (
@@ -41,11 +47,15 @@ let _lpKeyHandler = null;
  *   PER 7-8: exact distance number
  *   PER 9-10: exact distance + estimated zone range text
  */
-const hintInfo = (hint, lastDir, lastPos, perception) => {
+const hintInfo = (hint, lastDir, lastPos, perception, pickWear = 0) => {
   const arrow = lastDir > 0 ? '\u25B2' : lastDir < 0 ? '\u25BC' : '';
   if (hint < 0) return null; // no attempt yet
 
-  const per = perception || 5;
+  // Worn picks lose tactile resolution \u2014 bent tip = vaguer finger-feel
+  let per = perception || 5;
+  if (pickWear >= 3) per = Math.min(per, 3);
+  else if (pickWear >= 2) per = Math.min(per, 4);
+  else if (pickWear >= 1) per = Math.min(per, 5);
 
   if (per <= 3) {
     // Very low PER \u2014 just a direction
@@ -108,6 +118,12 @@ export const Lockpicking = (props, context) => {
     isDark,
     isHurt,
     wearingGloves,
+    hasTrait,
+    noiseLevel = 0,
+    timerDuration = 0,
+    timerElapsed = 0,
+    bindingPin = 0,
+    pickWear = 0,
   } = data;
 
   const isFinished = phase !== 'picking';
@@ -151,7 +167,7 @@ export const Lockpicking = (props, context) => {
       theme="fallout"
       title="Lock Picking"
       width={500}
-      height={580}>
+      height={640}>
       <Window.Content>
         <style>{PIN_PULSE_CSS}</style>
 
@@ -197,10 +213,43 @@ export const Lockpicking = (props, context) => {
                 {attemptsLeft} / {maxAttempts}
               </ProgressBar>
             </LabeledList.Item>
+            {!!timerDuration && (
+              <LabeledList.Item label="Hand Tension">
+                <ProgressBar
+                  value={timerDuration - timerElapsed}
+                  minValue={0}
+                  maxValue={timerDuration}
+                  ranges={{
+                    good: [timerDuration * 0.5, Infinity],
+                    average: [timerDuration * 0.2, timerDuration * 0.5],
+                    bad: [-Infinity, timerDuration * 0.2],
+                  }}>
+                  {/* eslint-disable-next-line max-len */}
+                  {Math.max(0, Math.ceil((timerDuration - timerElapsed) / 10))}s
+                  {' '}before hand cramps
+                </ProgressBar>
+              </LabeledList.Item>
+            )}
+            {!!pickWear && (
+              <LabeledList.Item label="Pick Condition">
+                <ProgressBar
+                  value={3 - pickWear}
+                  minValue={0}
+                  maxValue={3}
+                  ranges={{
+                    good: [2, Infinity],
+                    average: [1, 2],
+                    bad: [-Infinity, 1],
+                  }}>
+                  {PICK_WEAR_LABELS[pickWear]}
+                </ProgressBar>
+              </LabeledList.Item>
+            )}
           </LabeledList>
 
-          {/* Environmental penalty badges */}
-          {!!(isDark || isHurt || wearingGloves) && (
+          {/* Environmental penalty badges + trait bonus */}
+          {!!(isDark || isHurt || wearingGloves
+            || hasTrait || noiseLevel >= 3) && (
             <Box mt="4px" style={{ 'display': 'flex', 'gap': '4px', 'flex-wrap': 'wrap' }}>
               {!!isDark && (
                 <Box
@@ -239,6 +288,32 @@ export const Lockpicking = (props, context) => {
                     'color': '#80c080',
                   }}>
                   Glove penalty
+                </Box>
+              )}
+              {!!hasTrait && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#002222',
+                    'border': '1px solid #00aaaa',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#00dddd',
+                  }}>
+                  Locksmith
+                </Box>
+              )}
+              {noiseLevel >= 3 && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#2e2200',
+                    'border': '1px solid #8a6000',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#ddaa00',
+                  }}>
+                  Making noise ({noiseLevel}/5)
                 </Box>
               )}
             </Box>
@@ -281,7 +356,7 @@ export const Lockpicking = (props, context) => {
           <Box style={{ 'display': 'flex', 'justify-content': 'center', 'align-items': 'flex-start', 'flex-wrap': 'wrap' }}>
             {pins.map((pin, i) => {
               const heat = hintInfo(
-                pin.hint, pin.lastDir, pin.lastPos, perception
+                pin.hint, pin.lastDir, pin.lastPos, perception, pickWear
               );
               const isClickable = !isFinished && !pin.active && !pin.set;
               return (
@@ -291,22 +366,26 @@ export const Lockpicking = (props, context) => {
                   textAlign="center"
                   onClick={isClickable ? () => act('select_pin', { pin: i + 1 }) : undefined}
                   style={{
-                    'border': pin.active
-                      ? '1px solid #ffaa00'
-                      : pin.set
-                        ? '1px solid #00c853'
-                        : pin.security
-                          ? '1px solid #7a2a0a'
-                          : (pin.decayed && !pin.set)
-                            ? '1px solid #5a3a00'
-                            : '1px solid #333',
+                    'border': pin.set
+                      ? '1px solid #00c853'
+                      : (pin.active && i + 1 === bindingPin)
+                        ? '1px solid #ffaa00'
+                        : pin.active
+                          ? '1px solid #336633'
+                          : (i + 1 === bindingPin)
+                            ? '1px solid #aa7700'
+                            : (pin.decayed && !pin.set)
+                              ? '1px solid #5a3a00'
+                              : '1px solid #333',
                     'border-radius': '4px',
                     'padding': '4px 4px 6px 4px',
-                    'background': pin.active
+                    'background': (pin.active && i + 1 === bindingPin)
                       ? 'rgba(255,170,0,0.06)'
-                      : (pin.decayed && !pin.set)
-                        ? 'rgba(90,58,0,0.12)'
-                        : 'transparent',
+                      : pin.active
+                        ? 'rgba(76,255,76,0.03)'
+                        : (pin.decayed && !pin.set)
+                          ? 'rgba(90,58,0,0.12)'
+                          : 'transparent',
                     'animation': pin.active ? 'lpPinPulse 1.5s ease-in-out infinite' : undefined,
                     'min-width': '48px',
                     'cursor': isClickable ? 'pointer' : 'default',
@@ -320,11 +399,14 @@ export const Lockpicking = (props, context) => {
                     color={pin.set ? 'good' : pin.active ? 'yellow' : 'grey'}>
                     PIN {i + 1}
                   </Box>
-                  {!!pin.spool && !pin.set && (
-                    <Box fontSize="9px" color="yellow" italic>spool</Box>
+                  {!pin.set && i + 1 === bindingPin && (
+                    <Box fontSize="9px" color="#ffaa00" bold>BINDING</Box>
                   )}
-                  {!!pin.security && !pin.set && (
-                    <Box fontSize="9px" color="bad" italic>serrated</Box>
+                  {!pin.set && !!pin.active && i + 1 !== bindingPin && (
+                    <Box fontSize="9px" color="#4a7a4a">LOOSE</Box>
+                  )}
+                  {!!pin.overset && !pin.set && (
+                    <Box fontSize="9px" color="bad" bold>OVERDRIVEN</Box>
                   )}
 
                   {/* Segments \u2014 column-reverse so pos 1 = bottom */}
@@ -343,15 +425,23 @@ export const Lockpicking = (props, context) => {
                       if (pin.set) {
                         bg = '#00c853';
                       } else if (isCurrent && pin.active) {
-                        bg = '#ffaa00';
+                        if (pin.overset) {
+                          bg = '#aa2200'; // overdriven — blocked red
+                        } else if (pin.spoolFeel) {
+                          bg = '#cc7700'; // spool false-set feel — amber
+                        } else if (i + 1 !== bindingPin) {
+                          bg = '#1a3a1a'; // loose pin — dim green
+                        } else {
+                          bg = '#ffaa00'; // binding, normal — orange
+                        }
                       } else if (isCurrent) {
-                        bg = '#1e3060'; // subtle: shows where pin is parked
+                        bg = '#1a2a1a'; // subtle: shows where pin is parked
                       } else if (wasTried) {
                         const th = pin.triedHints && pin.triedHints[segPos];
                         if (th === 1) bg = '#7a2a0a'; // hot: one off
                         else if (th === 2) bg = '#5a3a00'; // warm: two off
-                        else if (th === 3) bg = '#1e2a4a'; // cool: three off
-                        else bg = '#1a1a3a'; // cold: far away
+                        else if (th === 3) bg = '#1e2a1e'; // cool: three off
+                        else bg = '#181a18'; // cold: far away
                       } else {
                         bg = '#1e1e1e';
                       }

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -1,11 +1,19 @@
-/**
- * Lockpicking.js — Semi-interactive lockpicking mini-game UI.
+﻿/**
+ * Lockpicking.js \u2014 Semi-interactive lockpicking mini-game UI.
  *
  * Shows a set of lock pins. The player moves each pin up or down
  * and presses "Set Pin" to try to lock it at the correct height.
  * After a failed attempt each pin shows a heat indicator (direction
- * arrow + "One notch off!" / "Getting close" / "Way off") so the
- * player can narrow in over successive tries.
+ * arrow + hint detail scaled by Perception) so the player can
+ * narrow in over successive tries.
+ *
+ * New features:
+ *  - Non-linear pin selection: click any unset pin to focus it
+ *  - Tried positions: previously failed positions shown in dim red
+ *  - Perception-scaled hints: low PER = vague, high PER = exact range
+ *  - Keyboard shortcuts: W/S/\u2191/\u2193 move, Space/Enter set,
+ *    Escape give up, 1-5 select pin
+ *  - Environmental penalty badges (darkness, injuries, gloves)
  */
 
 import { useBackend } from '../backend';
@@ -14,14 +22,65 @@ import { Window } from '../layouts';
 
 const TIER_LABELS = ['', 'Very Easy', 'Easy', 'Average', 'Hard', 'Very Hard'];
 
-/** Returns display info for the heat indicator based on distance from zone. */
-const hintInfo = (hint, lastDir) => {
-  const arrow = lastDir > 0 ? '▲' : lastDir < 0 ? '▼' : '';
+// CSS animation for the active pin glow pulse (injected via a <style> tag).
+const PIN_PULSE_CSS = (
+  '@keyframes lpPinPulse{'
+  + '0%,100%{box-shadow:0 0 5px rgba(255,170,0,0.3);}'
+  + '50%{box-shadow:0 0 10px rgba(255,170,0,0.8);}}'
+);
+
+// Module-level keyboard handler — Inferno v7 has no hooks,
+// so we manage the listener directly (single-instance interface).
+let _lpKeyHandler = null;
+
+/**
+ * Returns display info for the heat indicator.
+ * Detail level scales with Perception (1-10):
+ *   PER 1-3: direction only ("Off target")
+ *   PER 4-6: category labels (current behaviour)
+ *   PER 7-8: exact distance number
+ *   PER 9-10: exact distance + estimated zone range text
+ */
+const hintInfo = (hint, lastDir, lastPos, perception) => {
+  const arrow = lastDir > 0 ? '\u25B2' : lastDir < 0 ? '\u25BC' : '';
   if (hint < 0) return null; // no attempt yet
-  if (hint === 1) return { color: '#ff5722', label: 'One notch off!', arrow };
-  if (hint === 2) return { color: '#ff9800', label: 'Getting close', arrow };
-  if (hint === 3) return { color: '#42a5f5', label: 'Not quite', arrow };
-  return { color: '#1565c0', label: 'Way off', arrow };
+
+  const per = perception || 5;
+
+  if (per <= 3) {
+    // Very low PER \u2014 just a direction
+    return { color: '#7986cb', label: 'Off target', arrow };
+  }
+
+  // Base label from distance (PER 4+)
+  let color, label;
+  if (hint === 1) { color = '#ff5722'; label = 'One notch off!'; }
+  else if (hint === 2) { color = '#ff9800'; label = 'Getting close'; }
+  else if (hint === 3) { color = '#42a5f5'; label = 'Not quite'; }
+  else { color = '#1565c0'; label = 'Way off'; }
+
+  if (per >= 7 && lastPos) {
+    // High PER \u2014 show the estimated zone range
+    let rangeText;
+    if (lastDir > 0) {
+      // too low: zone_min = lastPos + 1, zone_max = lastPos + hint
+      const lo = lastPos + 1;
+      const hi = lastPos + hint;
+      rangeText = lo === hi ? `Try position ${lo}` : `Try ${lo}\u2013${hi}`;
+    } else {
+      // too high: zone_max = lastPos - 1, zone_min = lastPos - hint
+      const hi = lastPos - 1;
+      const lo = lastPos - hint;
+      rangeText = lo === hi ? `Try position ${lo}` : `Try ${lo}\u2013${hi}`;
+    }
+    if (per >= 9) {
+      label = rangeText;
+    } else {
+      label = `${label} (${rangeText})`;
+    }
+  }
+
+  return { color, label, arrow };
 };
 
 /** Returns display info for pick tension (moves accumulated on current pin). */
@@ -43,23 +102,60 @@ export const Lockpicking = (props, context) => {
     feedback,
     lockTier,
     luck,
+    perception = 5,
     isMasterPick,
     totalPins,
+    isDark,
+    isHurt,
+    wearingGloves,
   } = data;
 
   const isFinished = phase !== 'picking';
   const activePinIndex = pins.findIndex(p => p.active);
   const activePin = activePinIndex !== -1 ? pins[activePinIndex] : null;
 
+  // Keyboard shortcuts — swap handler on each render so it closes
+  // over the latest act/data values.
+  if (_lpKeyHandler) {
+    document.removeEventListener('keydown', _lpKeyHandler);
+  }
+  if (!isFinished) {
+    _lpKeyHandler = (e) => {
+      if (e.key === 'w' || e.key === 'W' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        act('move_up');
+      } else if (e.key === 's' || e.key === 'S' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        act('move_down');
+      } else if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        act('set_pin');
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        act('give_up');
+      } else if (e.key >= '1' && e.key <= '5') {
+        const idx = parseInt(e.key, 10);
+        if (idx <= pins.length && !pins[idx - 1].set) {
+          e.preventDefault();
+          act('select_pin', { pin: idx });
+        }
+      }
+    };
+    document.addEventListener('keydown', _lpKeyHandler);
+  } else {
+    _lpKeyHandler = null;
+  }
+
   return (
     <Window
       theme="fallout"
       title="Lock Picking"
       width={500}
-      height={520}>
+      height={580}>
       <Window.Content>
+        <style>{PIN_PULSE_CSS}</style>
 
-        {/* ── Status ───────────────────────────────────────── */}
+        {/* Status */}
         <Section title="Lock Status">
           <LabeledList>
             <LabeledList.Item label="Difficulty">
@@ -85,7 +181,7 @@ export const Lockpicking = (props, context) => {
                   average: [3, 6],
                   good: [6, Infinity],
                 }}>
-                {luck} / 10{isMasterPick ? ' — Master Pick' : ''}
+                {luck} / 10{isMasterPick ? ' \u2014 Master Pick' : ''}
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item label="Attempts Left">
@@ -102,35 +198,118 @@ export const Lockpicking = (props, context) => {
               </ProgressBar>
             </LabeledList.Item>
           </LabeledList>
+
+          {/* Environmental penalty badges */}
+          {!!(isDark || isHurt || wearingGloves) && (
+            <Box mt="4px" style={{ 'display': 'flex', 'gap': '4px', 'flex-wrap': 'wrap' }}>
+              {!!isDark && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#1a1a2e',
+                    'border': '1px solid #4a4a7a',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#9090d0',
+                  }}>
+                  Darkness penalty
+                </Box>
+              )}
+              {!!isHurt && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#2e1a1a',
+                    'border': '1px solid #7a2a2a',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#d08080',
+                  }}>
+                  Injury penalty
+                </Box>
+              )}
+              {!!wearingGloves && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#1a2e1a',
+                    'border': '1px solid #2a6a2a',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#80c080',
+                  }}>
+                  Glove penalty
+                </Box>
+              )}
+            </Box>
+          )}
         </Section>
 
-        {/* ── Feedback ─────────────────────────────────────── */}
+        {/* Feedback */}
         <NoticeBox
           success={phase === 'success'}
           danger={phase === 'failed'}>
           {feedback}
         </NoticeBox>
 
-        {/* ── Pins ─────────────────────────────────────────── */}
-        <Section title={`Pins — ${pinsSet} / ${totalPins} Set`}>
+        {/* Pins */}
+        <Section title={`Pins \u2014 ${pinsSet} / ${totalPins} Set`}>
+          {!isFinished && (
+            <Box
+              mb="2px"
+              fontSize="10px"
+              color="label"
+              textAlign="center">
+              {'Click any unset pin. Keys: W/↑ up · S/↓ down · Space set · Esc give up · 1-5 select pin'}
+            </Box>
+          )}
+          {!!activePin && !isFinished && (
+            <Box mb="4px">
+              <ProgressBar
+                value={activePin.tension}
+                minValue={0}
+                maxValue={10}
+                ranges={{
+                  good: [-Infinity, 3],
+                  average: [3, 6],
+                  bad: [6, Infinity],
+                }}>
+                Pick tension: {activePin.tension} / 10
+              </ProgressBar>
+            </Box>
+          )}
           <Box style={{ 'display': 'flex', 'justify-content': 'center', 'align-items': 'flex-start', 'flex-wrap': 'wrap' }}>
             {pins.map((pin, i) => {
-              const heat = hintInfo(pin.hint, pin.lastDir);
+              const heat = hintInfo(
+                pin.hint, pin.lastDir, pin.lastPos, perception
+              );
+              const isClickable = !isFinished && !pin.active && !pin.set;
               return (
                 <Box
                   key={i}
                   mx="5px"
                   textAlign="center"
+                  onClick={isClickable ? () => act('select_pin', { pin: i + 1 }) : undefined}
                   style={{
                     'border': pin.active
                       ? '1px solid #ffaa00'
                       : pin.set
                         ? '1px solid #00c853'
-                        : '1px solid #333',
+                        : pin.security
+                          ? '1px solid #7a2a0a'
+                          : (pin.decayed && !pin.set)
+                            ? '1px solid #5a3a00'
+                            : '1px solid #333',
                     'border-radius': '4px',
                     'padding': '4px 4px 6px 4px',
-                    'background': pin.active ? 'rgba(255,170,0,0.06)' : 'transparent',
+                    'background': pin.active
+                      ? 'rgba(255,170,0,0.06)'
+                      : (pin.decayed && !pin.set)
+                        ? 'rgba(90,58,0,0.12)'
+                        : 'transparent',
+                    'animation': pin.active ? 'lpPinPulse 1.5s ease-in-out infinite' : undefined,
                     'min-width': '48px',
+                    'cursor': isClickable ? 'pointer' : 'default',
                   }}>
 
                   {/* Pin label */}
@@ -141,24 +320,38 @@ export const Lockpicking = (props, context) => {
                     color={pin.set ? 'good' : pin.active ? 'yellow' : 'grey'}>
                     PIN {i + 1}
                   </Box>
+                  {!!pin.spool && !pin.set && (
+                    <Box fontSize="9px" color="yellow" italic>spool</Box>
+                  )}
+                  {!!pin.security && !pin.set && (
+                    <Box fontSize="9px" color="bad" italic>serrated</Box>
+                  )}
 
-                  {/* Segments — column-reverse so pos 1 = bottom */}
+                  {/* Segments \u2014 column-reverse so pos 1 = bottom */}
                   <Box style={{
                     'display': 'flex',
                     'flex-direction': 'column-reverse',
                     'align-items': 'center',
-                    'gap': '2px',
+                    'gap': '1px',
                   }}>
                     {Array.from({ length: 10 }, (_, si) => {
                       const segPos = si + 1;
                       const isCurrent = !pin.set && pin.pos === segPos;
+                      const wasTried = !pin.set
+                        && pin.tried && pin.tried.includes(segPos);
                       let bg;
                       if (pin.set) {
                         bg = '#00c853';
                       } else if (isCurrent && pin.active) {
                         bg = '#ffaa00';
                       } else if (isCurrent) {
-                        bg = '#3a7abf';
+                        bg = '#1e3060'; // subtle: shows where pin is parked
+                      } else if (wasTried) {
+                        const th = pin.triedHints && pin.triedHints[segPos];
+                        if (th === 1) bg = '#7a2a0a'; // hot: one off
+                        else if (th === 2) bg = '#5a3a00'; // warm: two off
+                        else if (th === 3) bg = '#1e2a4a'; // cool: three off
+                        else bg = '#1a1a3a'; // cold: far away
                       } else {
                         bg = '#1e1e1e';
                       }
@@ -171,7 +364,9 @@ export const Lockpicking = (props, context) => {
                             'background-color': bg,
                             'border': isCurrent && pin.active
                               ? '1px solid #ffcc00'
-                              : '1px solid #2e2e2e',
+                              : wasTried
+                                ? '1px solid #5a2a2a'
+                                : '1px solid #2e2e2e',
                             'border-radius': '2px',
                           }}
                         />
@@ -182,24 +377,26 @@ export const Lockpicking = (props, context) => {
                   {/* Position label */}
                   <Box mt="3px" fontSize="11px">
                     {pin.set ? (
-                      <Box color="good" bold>✓</Box>
+                      <Box color="good" bold>{'✓'}</Box>
                     ) : pin.active ? (
                       <Box color="label">{pin.pos} / 10</Box>
+                    ) : pin.decayed ? (
+                      <Box color="average" bold>{'!'}</Box>
                     ) : (
-                      <Box color="grey">—</Box>
+                      <Box color="grey">{'—'}</Box>
                     )}
                   </Box>
 
-                  {/* Heat hint + tension warning — only shown on active pin */}
-                  <Box style={{ 'min-height': '42px' }}>
-                    {pin.active && heat && (
+                  {/* Heat hint (inactive pins show faded hint) */}
+                  <Box style={{ 'min-height': '30px' }}>
+                    {!!pin.active && heat && (
                       <Box mt="3px" fontSize="11px" color={heat.color} bold>
                         {heat.arrow} {heat.label}
                       </Box>
                     )}
-                    {pin.active && tensionInfo(pin.tension) && (
-                      <Box mt="2px" fontSize="10px" color={tensionInfo(pin.tension).color} bold>
-                        ⚠ {tensionInfo(pin.tension).label}
+                    {!pin.active && !pin.set && heat && (
+                      <Box mt="3px" fontSize="10px" color="#555" italic>
+                        {heat.arrow} {heat.label}
                       </Box>
                     )}
                   </Box>
@@ -209,7 +406,7 @@ export const Lockpicking = (props, context) => {
           </Box>
         </Section>
 
-        {/* ── Controls ─────────────────────────────────────── */}
+        {/* Controls */}
         {!isFinished && activePin !== null && (
           <Section>
             <Box textAlign="center">
@@ -248,7 +445,7 @@ export const Lockpicking = (props, context) => {
               color={phase === 'success' ? 'good' : 'bad'}
               fontSize="14px"
               bold>
-              {phase === 'success' ? '— Lock Opened —' : '— Lock Picking Failed —'}
+              {phase === 'success' ? '\u2014 Lock Opened \u2014' : '\u2014 Lock Picking Failed \u2014'}
             </Box>
           </Section>
         )}

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -519,7 +519,7 @@ export const Lockpicking = (props, context) => {
                     )}
                   </Box>
 
-                  {/* Per-pin try meter — separate from the global trap-attempt bar */}
+                  {/* Per-pin try meter — separate from global trap-attempt bar */}
                   {!pin.set && (
                     <Box mt="2px" style={{
                       'display': 'flex',

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -166,8 +166,8 @@ export const Lockpicking = (props, context) => {
     <Window
       theme="fallout"
       title="Lock Picking"
-      width={500}
-      height={640}>
+      width={620}
+      height={700}>
       <Window.Content>
         <style>{PIN_PULSE_CSS}</style>
 
@@ -320,12 +320,15 @@ export const Lockpicking = (props, context) => {
           )}
         </Section>
 
-        {/* Feedback */}
-        <NoticeBox
-          success={phase === 'success'}
-          danger={phase === 'failed'}>
-          {feedback}
-        </NoticeBox>
+        {/* Feedback — fixed min-height prevents the pin section shifting
+             when short (1-line) messages swap for long (2-line) messages */}
+        <Box style={{ 'min-height': '50px' }}>
+          <NoticeBox
+            success={phase === 'success'}
+            danger={phase === 'failed'}>
+            {feedback}
+          </NoticeBox>
+        </Box>
 
         {/* Pins */}
         <Section title={`Pins \u2014 ${pinsSet} / ${totalPins} Set`}>
@@ -353,7 +356,19 @@ export const Lockpicking = (props, context) => {
               </ProgressBar>
             </Box>
           )}
-          <Box style={{ 'display': 'flex', 'justify-content': 'center', 'align-items': 'flex-start', 'flex-wrap': 'wrap' }}>
+          {/* No-wrap row: pins never reflow to a second row.
+               overflow-x:auto is a safety net for very high pin counts.
+               min-height reserves consistent space so controls don't jump. */}
+          <Box style={{
+            'display': 'flex',
+            'justify-content': 'center',
+            'align-items': 'flex-start',
+            'flex-wrap': 'nowrap',
+            'overflow-x': 'auto',
+            'overflow-y': 'visible',
+            'min-height': '225px',
+            'padding-bottom': '4px',
+          }}>
             {pins.map((pin, i) => {
               const heat = hintInfo(
                 pin.hint, pin.lastDir, pin.lastPos, perception, pickWear
@@ -387,7 +402,8 @@ export const Lockpicking = (props, context) => {
                           ? 'rgba(90,58,0,0.12)'
                           : 'transparent',
                     'animation': pin.active ? 'lpPinPulse 1.5s ease-in-out infinite' : undefined,
-                    'min-width': '48px',
+                    'width': '88px',
+                    'flex-shrink': '0',
                     'cursor': isClickable ? 'pointer' : 'default',
                   }}>
 
@@ -497,8 +513,9 @@ export const Lockpicking = (props, context) => {
                     </Box>
                   )}
 
-                  {/* Heat hint (inactive pins show faded hint) */}
-                  <Box style={{ 'min-height': '30px' }}>
+                  {/* Heat hint — word-break ensures long range labels
+                       wrap inside the fixed-width card */}
+                  <Box style={{ 'min-height': '30px', 'word-break': 'break-word', 'overflow-wrap': 'break-word' }}>
                     {!!pin.active && heat && (
                       <Box mt="3px" fontSize="11px" color={heat.color} bold>
                         {heat.arrow} {heat.label}

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -124,6 +124,7 @@ export const Lockpicking = (props, context) => {
     timerElapsed = 0,
     bindingPin = 0,
     pickWear = 0,
+    isSneaking = false,
   } = data;
 
   const isFinished = phase !== 'picking';
@@ -249,7 +250,7 @@ export const Lockpicking = (props, context) => {
 
           {/* Environmental penalty badges + trait bonus */}
           {!!(isDark || isHurt || wearingGloves
-            || hasTrait || noiseLevel >= 3) && (
+            || hasTrait || noiseLevel >= 3 || isSneaking) && (
             <Box mt="4px" style={{ 'display': 'flex', 'gap': '4px', 'flex-wrap': 'wrap' }}>
               {!!isDark && (
                 <Box
@@ -314,6 +315,19 @@ export const Lockpicking = (props, context) => {
                     'color': '#ddaa00',
                   }}>
                   Making noise ({noiseLevel}/5)
+                </Box>
+              )}
+              {!!isSneaking && (
+                <Box
+                  fontSize="11px"
+                  style={{
+                    'background': '#001a1a',
+                    'border': '1px solid #006666',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'color': '#00cccc',
+                  }}>
+                  Walk mode — muffled
                 </Box>
               )}
             </Box>

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -38,6 +38,11 @@ const PIN_PULSE_CSS = (
 // Module-level keyboard handler — Inferno v7 has no hooks,
 // so we manage the listener directly (single-instance interface).
 let _lpKeyHandler = null;
+// Throttle: movement keys are capped at one topic call per 250ms (~4/s).
+// BYOND enforces a 100-topic/minute hard limit; rapid key-hold would blow past
+// it in seconds without this guard. Set/select pins are unthrottled (rare, intentional clicks).
+let _lpLastMoveTime = 0;
+const LP_MOVE_THROTTLE_MS = 250;
 
 /**
  * Returns display info for the heat indicator.
@@ -140,9 +145,15 @@ export const Lockpicking = (props, context) => {
     _lpKeyHandler = (e) => {
       if (e.key === 'w' || e.key === 'W' || e.key === 'ArrowUp') {
         e.preventDefault();
+        const now = Date.now();
+        if (now - _lpLastMoveTime < LP_MOVE_THROTTLE_MS) return;
+        _lpLastMoveTime = now;
         act('move_up');
       } else if (e.key === 's' || e.key === 'S' || e.key === 'ArrowDown') {
         e.preventDefault();
+        const now = Date.now();
+        if (now - _lpLastMoveTime < LP_MOVE_THROTTLE_MS) return;
+        _lpLastMoveTime = now;
         act('move_down');
       } else if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault();
@@ -554,13 +565,23 @@ export const Lockpicking = (props, context) => {
               <Button
                 icon="arrow-up"
                 mr={1}
-                onClick={() => act('move_up')}>
+                onClick={() => {
+                  const now = Date.now();
+                  if (now - _lpLastMoveTime < LP_MOVE_THROTTLE_MS) return;
+                  _lpLastMoveTime = now;
+                  act('move_up');
+                }}>
                 Move Up
               </Button>
               <Button
                 icon="arrow-down"
                 mr={1}
-                onClick={() => act('move_down')}>
+                onClick={() => {
+                  const now = Date.now();
+                  if (now - _lpLastMoveTime < LP_MOVE_THROTTLE_MS) return;
+                  _lpLastMoveTime = now;
+                  act('move_down');
+                }}>
                 Move Down
               </Button>
               <Button

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -200,7 +200,7 @@ export const Lockpicking = (props, context) => {
                 {luck} / 10{isMasterPick ? ' \u2014 Master Pick' : ''}
               </ProgressBar>
             </LabeledList.Item>
-            <LabeledList.Item label="Attempts Left">
+            <LabeledList.Item label="Attempts">
               <ProgressBar
                 value={attemptsLeft}
                 minValue={0}
@@ -476,6 +476,26 @@ export const Lockpicking = (props, context) => {
                       <Box color="grey">{'—'}</Box>
                     )}
                   </Box>
+
+                  {/* Per-pin try meter — separate from the global trap-attempt bar */}
+                  {!pin.set && (
+                    <Box mt="2px" style={{ 'display': 'flex', 'justify-content': 'center', 'gap': '3px' }}>
+                      {Array.from({ length: 2 }, (_, ai) => (
+                        <Box
+                          key={ai}
+                          style={{
+                            'width': '8px',
+                            'height': '8px',
+                            'border-radius': '50%',
+                            'background-color': ai < (pin.pinAttempts || 0)
+                              ? ((pin.pinAttempts || 0) <= 1 ? '#ff5722' : '#ffcc00')
+                              : '#2e2e2e',
+                            'border': `1px solid ${ai < (pin.pinAttempts || 0) ? '#888' : '#444'}`,
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  )}
 
                   {/* Heat hint (inactive pins show faded hint) */}
                   <Box style={{ 'min-height': '30px' }}>

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -519,7 +519,6 @@ export const Lockpicking = (props, context) => {
                     )}
                   </Box>
 
-                  {/* Per-pin try meter — separate from global trap-attempt bar */}
                   {!pin.set && (
                     <Box mt="2px" style={{
                       'display': 'flex',

--- a/tgui/packages/tgui/interfaces/Lockpicking.js
+++ b/tgui/packages/tgui/interfaces/Lockpicking.js
@@ -40,7 +40,8 @@ const PIN_PULSE_CSS = (
 let _lpKeyHandler = null;
 // Throttle: movement keys are capped at one topic call per 250ms (~4/s).
 // BYOND enforces a 100-topic/minute hard limit; rapid key-hold would blow past
-// it in seconds without this guard. Set/select pins are unthrottled (rare, intentional clicks).
+// it in seconds without this guard. Set/select pins are unthrottled
+// (rare, intentional clicks).
 let _lpLastMoveTime = 0;
 const LP_MOVE_THROTTLE_MS = 250;
 
@@ -520,7 +521,11 @@ export const Lockpicking = (props, context) => {
 
                   {/* Per-pin try meter — separate from the global trap-attempt bar */}
                   {!pin.set && (
-                    <Box mt="2px" style={{ 'display': 'flex', 'justify-content': 'center', 'gap': '3px' }}>
+                    <Box mt="2px" style={{
+                      'display': 'flex',
+                      'justify-content': 'center',
+                      'gap': '3px',
+                    }}>
                       {Array.from({ length: 2 }, (_, ai) => (
                         <Box
                           key={ai}

--- a/tgui/packages/tgui/styles/themes/fallout.scss
+++ b/tgui/packages/tgui/styles/themes/fallout.scss
@@ -105,6 +105,18 @@ $phosphor-text: #a8d8a8;
     color: #c8ffc8;
   }
 
+  // All fills unified to phosphor-dim so mix-blend-mode:difference produces
+  // near-black text over the fill and bright phosphor text on the dark track.
+  .ProgressBar--color--good,
+  .ProgressBar--color--average,
+  .ProgressBar--color--bad {
+    border-color: $phosphor-dim !important;
+
+    .ProgressBar__fill {
+      background-color: $phosphor-dim;
+    }
+  }
+
   .ProgressBar__content {
     color: $phosphor;
     mix-blend-mode: difference;


### PR DESCRIPTION
## About The Pull Request

<img width="618" height="699" alt="image" src="https://github.com/user-attachments/assets/408d0b50-d34e-4055-a491-737998b8c0b5" />


https://github.com/user-attachments/assets/c7f4d783-e1b7-462c-855d-cef957b62ab3


Adds a pin-tumbler lockpicking minigame to replace the old single prob() roll. Player works each pin individually via a TGUI panel, using keyboard or buttons to move pins up/down and set them when in the correct zone.

Core loop: locks have 1-5 tiers with varying pin counts and zone sizes. Only the binding pin can actually be set at any given time — non-binding pins spring back. Failed attempts give directional/distance feedback scaled by Perception. Too many moves on one pin snaps the pick and jams the lock.

Tier 3+ adds spool pins (must approach from below), security pins (failed set knocks a neighbor loose), pin decay (set pins can vibrate free), a false zone decoy, and a tension-fatigue timer that drops all pins when it expires.

Four pick variants: standard, master set (wider zones, quieter, holds pins on interrupt), tension wrench (halves decay, saves pins on give-up for 60s), bobby pin (tier 1-2 only, loud, 25% snap chance), electronic pick (auto-sets first pin, bypasses false zones).

Lock combinations are generated once per lock object and persist across attempts so the same lock always has the same solution.

Sneaking (walk intent) cuts sounds to ~50%, shrinks noise alert range, and burns the fatigue timer 30% faster.

Observers nearby get perception-gated chat messages on every pin attempt. Low PER gets a vague click, high PER gets pin number and miss quality. Failed attempts broadcast up to 8 tiles, successful sets only 4. A lockpick icon floats above the picker visible to anyone in view, opacity scales with picker skill.

TRAIT_LOCKPICKING (new Locksmith quirk, 4pts) widens zones, quiets hands, and extends the fatigue timer. Also learnable from a rare book.

UI is 620x700 TGUI with horizontal-scrolling pin cards, heat indicators, pick wear bar, fatigue timer, and penalty badges. Added 250ms client-side throttle on move inputs — key-hold was hitting BYOND's 100 topic/minute limit.

Hooks into: simple_door padlocks, machinery/door padlocks, locked boxes. Muffles door-open sound on success. Blast/pod doors not affected.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: New lockpicking minigame pick locks pin by pin instead of a single luck roll
add: Five lock tiers with increasing pin counts, zone sizes, and special pin types (spool, security, false zones)
add: Four lockpick variants: standard set, master set, tension wrench, bobby pin, electronic pick
add: Locksmith quirk (4pts) grants wider feel zones, quieter hands, and extended fatigue timer
add: Observers nearby see and hear lockpicking attempts, detail gated by Perception
add: Lock combinations persist per lock object same lock, same combination every time
add: Partial state saving for tension wrench and master pick on give-up or interruption
tweak: Sneaking while picking cuts sounds, shrinks noise range, burns fatigue timer faster
tweak: Pick durability now drains by moves made, not just on outcome
fix: Key-hold no longer spams BYOND topic calls past the per-minute limit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
