### PR TITLE
Fixing search chatter spam

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -191,7 +191,12 @@
 	/// Cooldown between backup calls to prevent spam
 	COOLDOWN_DECLARE(backup_call_cooldown)
 	/// How long between backup calls (deciseconds)
-	var/backup_call_delay = 50 // 5 seconds
+	var/backup_call_delay = 300 // 30 seconds
+
+	/// Rate-limit search chatter visible_messages (looks around, resumes hunt, moves to investigate)
+	/// Prevents spam when many mobs cycle search mode simultaneously
+	COOLDOWN_DECLARE(search_chatter_cooldown)
+	var/search_chatter_delay = 300 // 30 seconds
 
 	/// Are we currently rallying to allies?
 	var/rallying = FALSE
@@ -3114,7 +3119,9 @@
 	recently_opened_door = null
 	investigating_container = null
 
-	visible_message(span_warning("[src] looks around suspiciously..."))
+	if(COOLDOWN_FINISHED(src, search_chatter_cooldown))
+		COOLDOWN_START(src, search_chatter_cooldown, search_chatter_delay)
+		visible_message(span_warning("[src] looks around suspiciously..."))
 
 	if(is_alpha_alerter)
 		if(target)
@@ -3149,7 +3156,9 @@
 			visible_message(span_notice("[src] gives up the search."))
 		LoseTarget()
 	else
-		visible_message(span_danger("[src] resumes the hunt!"))
+		if(COOLDOWN_FINISHED(src, search_chatter_cooldown))
+			COOLDOWN_START(src, search_chatter_cooldown, search_chatter_delay)
+			visible_message(span_danger("[src] resumes the hunt!"))
 		// is_alpha_alerter stays as-is - if we found the target we may now broadcast
 
 /mob/living/simple_animal/hostile/proc/search_for_target()
@@ -3370,7 +3379,9 @@
 					attempt_z_pursuit()
 				addtimer(CALLBACK(src, PROC_REF(search_for_target)), 3 SECONDS, TIMER_DELETE_ME)
 				return
-			visible_message(span_warning("[src] moves to investigate the last known position..."))
+			if(COOLDOWN_FINISHED(src, search_chatter_cooldown))
+				COOLDOWN_START(src, search_chatter_cooldown, search_chatter_delay)
+				visible_message(span_warning("[src] moves to investigate the last known position..."))
 			Goto(last_known_location, move_to_delay, 0)
 			addtimer(CALLBACK(src, PROC_REF(search_for_target)), 3 SECONDS, TIMER_DELETE_ME)
 			return


### PR DESCRIPTION
## About The Pull Request

**Search Mode Spam**
- When a player entered crit with many mobs nearby, each mob independently announced every search state transition — "looks around suspiciously", "resumes the hunt!", "moves to investigate", etc. — flooding chat with hundreds of messages per second. All search-flavored visible messages are now rate-limited to once per mob per 30 seconds. The backup/ally-alert cooldown was also increased from 5 seconds to 30 seconds.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Hostile mob search chatter no longer spams chat when many mobs are searching simultaneously
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
