### PR TITLE
Fix vehicle siren spam and spawn book display

### DIFF
--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -287,15 +287,23 @@
 /datum/action/innate/mecha/klaxon
 	name = "Klaxon"
 	button_icon_state = "mech_damtype_brute"
+	var/next_use_time = 0
 
 /datum/action/innate/mecha/klaxon/Activate()
+	if(world.time < next_use_time)
+		return
+	next_use_time = world.time + 18 // matches klaxon.ogg duration (~1.7s) to prevent stacking
 	playsound(chassis,'sound/f13machines/klaxon.ogg', 50, 1)
 
 /datum/action/innate/mecha/sirens
 	name = "Sirens"
 	button_icon_state = "mech_damtype_brute"
+	var/next_use_time = 0
 
 /datum/action/innate/mecha/sirens/Activate()
+	if(world.time < next_use_time)
+		return
+	next_use_time = world.time + 300 // police.ogg duration (~20.9s) + buffer for client latency
 	playsound(chassis,'sound/f13machines/police.ogg', 50, 1)
 
 // LAND BIRD LAND

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -232,7 +232,15 @@
 	show_to(O)
 
 /obj/item/book/proc/show_to(mob/user)
-	user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
+	var/book_header = author ? "<h3>Penned by <i>[author]</i></h3><hr>" : ""
+	var/content
+	if(dat && findtext(dat, "<html") == 1)
+		// dat is already a full HTML document; inject the author header after <body>
+		content = replacetext(dat, "<body>", "<body>[book_header]")
+	else
+		// dat has HTML fragments; wrap in a proper HTML5 skeleton for Chromium compatibility
+		content = HTML_SKELETON_TITLE("[title]", "[book_header][dat]")
+	user << browse(content, "window=book[window_size != null ? ";size=[window_size]" : ""]")
 
 /obj/item/book/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen))


### PR DESCRIPTION
## About The Pull Request
Fixes two reported bugs:

- Vehicle klaxon/sirens could be spammed, stacking overlapping sounds. Both actions now track next_use_time and are locked for the exact duration of their respective sound files (klaxon ~1.7s, police siren ~22s) so they can't be re-triggered while playing.

- The spawn book "Survival Guide to the Wastes" (and other books with full HTML dat) displayed raw code instead of rendered content in BYOND 516+. The old show_to proc prepended a plain-text author header before the HTML document, causing Chromium to render the CSS style block as visible text. The proc now detects whether dat is already a full HTML document and injects the author line inside the body tag instead of prepending it before the document.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Klaxon and siren actions on vehicles now have a cooldown matching their sound file duration, preventing sound stacking from spam
fix: Books with full HTML content (such as the Survival Guide to the Wastes given at spawn) now render correctly in BYOND 516+ instead of displaying raw HTML code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
