### PR TITLE
Total SS13 power death

### DIFF
--- a/code/modules/f13_power_grid/_defines.dm
+++ b/code/modules/f13_power_grid/_defines.dm
@@ -167,6 +167,10 @@ GLOBAL_LIST_EMPTY(f13_trace_log)
 	A.power_equip   = state
 	A.power_light   = state
 	A.power_environ = state
+	// Sync immediately so checks never see stale state regardless of which async path fires.
+	var/area/f13/fa = A
+	if(istype(fa))
+		fa.f13_grid_power = state
 	if(state)
 		f13_log_op("stamp_area ON [A.name] (async queued)")
 		INVOKE_ASYNC(A, TYPE_PROC_REF(/area, power_change))

--- a/fallout/areas/area.dm
+++ b/fallout/areas/area.dm
@@ -30,6 +30,12 @@
 /// F13 areas have no APC, so buttons are never iterated by the normal
 /// machinery-notification path — we must push the update ourselves.
 /area/f13/power_change()
+	// An APC with no powernet cleared power_equip while the F13 grid is live — reject it.
+	if(f13_grid_power && !power_equip)
+		power_equip   = TRUE
+		power_light   = TRUE
+		power_environ = TRUE
+		return
 	f13_grid_power = power_equip
 	// Notify buttons on any turf (open or closed) WITHIN this area.
 	for(var/obj/machinery/button/B in src)


### PR DESCRIPTION
## About The Pull Request
APCs will no longer work in f13 power grids

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
code: APCs no longer interfere with F13 faction power grids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
